### PR TITLE
Adjust CI/CD

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -23,21 +23,20 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
+    # Get the GKE credentials so we can deploy to the cluster
+    - uses: 'google-github-actions/auth@v0'
+      with:
+        credentials_json: ${{ secrets.GKE_SA_KEY }}
+
     # Setup gcloud CLI
     - uses: google-github-actions/setup-gcloud@v0.6.0
       with:
-        service_account_key: ${{ secrets.GKE_SA_KEY }}
         project_id: ${{ secrets.GKE_PROJECT }}
 
     # Configure Docker to use the gcloud command-line tool as a credential
     # helper for authentication
     - run: |-
         gcloud --quiet auth configure-docker
-
-    # Get the GKE credentials so we can deploy to the cluster    
-    - uses: 'google-github-actions/auth@v0'
-      with:
-        credentials_json: ${{ secrets.GKE_SA_KEY }}
 
     - uses: google-github-actions/get-gke-credentials@v0.8.0
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,22 +16,28 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: ["csharp"]
+        language: ["csharp", "javascript"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2
         with:
           languages: ${{ matrix.language }}
+          queries: security-and-quality
+
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 6.0.x
+
       - name: Restore dependencies
         run: dotnet restore src
+
       - name: Build
         run: dotnet build src --configuration Release --no-restore
+
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2
 
@@ -39,23 +45,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 6.0.x
-      - name: Restore dependencies
+
+      - name: Restore Dependencies
         run: dotnet restore src
+
       - name: Build
         run: dotnet build src --configuration Release --no-restore
-      - name: Unit Test With Coverage Report
+
+      - name: Unit Test
         run: |
-          cd src/Tests/Coding.Blog.UnitTests/
-          dotnet test --no-restore /p:CollectCoverage=true /p:CoverletOutput=TestResults/ /p:CoverletOutputFormat=lcov
-      - name: Publish Coverage Report
-        uses: coverallsapp/github-action@master
+          cd ./src/Tests/Coding.Blog.UnitTests/
+          dotnet test --no-restore /p:CollectCoverage=true /p:CoverletOutput=/home/runner/work/coding-blog/coding-blog/ /p:CoverletOutputFormat=opencover
+
+      - name: Publish Code Coverage
+        uses: codecov/codecov-action@v3
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: src/Tests/Coding.Blog.UnitTests/TestResults/coverage.info
+          files: /home/runner/work/coding-blog/coding-blog/coverage.opencover.xml
+          fail_ci_if_error: true
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: ["csharp", "javascript"]
+        language: ["csharp"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3


### PR DESCRIPTION
- Remove deprecated `service_account_key` usage in `google-github-actions/setup-gcloud@v0.6.0`
- Add JS CodeQL scanning and use the `security-and-quality` extended CodeQL query
- Swap from coveralls to codecov for coverage reporting