### PR TITLE
Tweaks

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -2,3 +2,8 @@
 
 # file name must match type name
 dotnet_diagnostic.MA0048.severity = none
+
+[*.cs]
+
+# add trailing commas
+dotnet_diagnostic.MA0007.severity = none

--- a/src/Coding.Blog/Engine/Clients/CosmicRequestRegistry.cs
+++ b/src/Coding.Blog/Engine/Clients/CosmicRequestRegistry.cs
@@ -8,6 +8,6 @@ internal static class CosmicRequestRegistry
         (StringComparer.OrdinalIgnoreCase)
         {
             { typeof(CosmicBooks).FullName!, new CosmicRequest("books", "title,content,metadata,created_at") },
-            { typeof(CosmicPosts).FullName!, new CosmicRequest("posts", "id,slug,title,metadata,created_at") },
+            { typeof(CosmicPosts).FullName!, new CosmicRequest("posts", "id,slug,title,metadata,created_at") }
         };
 }

--- a/src/Coding.Blog/Engine/Extensions/GrpcResilienceConfigurationExtensions.cs
+++ b/src/Coding.Blog/Engine/Extensions/GrpcResilienceConfigurationExtensions.cs
@@ -18,7 +18,7 @@ public static class GrpcResilienceConfigurationExtensions
             MaxAttempts = int.Parse(configuration["GrpcResilience:MaxAttempts"]!, CultureInfo.InvariantCulture),
             BackoffMultiplier = double.Parse(configuration["GrpcResilience:BackoffMultiplier"]!, CultureInfo.InvariantCulture),
             InitialBackoffMilliseconds = int.Parse(configuration["GrpcResilience:InitialBackoffMilliseconds"]!, CultureInfo.InvariantCulture),
-            MaxBackoffMilliseconds = int.Parse(configuration["GrpcResilience:MaxBackoffMilliseconds"]!, CultureInfo.InvariantCulture),
+            MaxBackoffMilliseconds = int.Parse(configuration["GrpcResilience:MaxBackoffMilliseconds"]!, CultureInfo.InvariantCulture)
         }
     );
 }

--- a/src/Tests/Coding.Blog.UnitTests/Clients/CosmicClientTests.cs
+++ b/src/Tests/Coding.Blog.UnitTests/Clients/CosmicClientTests.cs
@@ -13,7 +13,7 @@ using Polly;
 namespace Coding.Blog.UnitTests.Clients;
 
 [TestFixture]
-public sealed class CosmicClientTests
+internal sealed class CosmicClientTests
 {
     private CosmicConfiguration _configuration = default!;
     private ILogger<CosmicBooks> _mockLogger = default!;
@@ -48,7 +48,7 @@ public sealed class CosmicClientTests
             }
         ));
 
-        var client = new CosmicClient<CosmicBooks>(_configuration!, _mockLogger!, _resiliencePolicy!);
+        var client = new CosmicClient<CosmicBooks>(_configuration, _mockLogger, _resiliencePolicy);
 
         // act
         var response = await client.GetAsync();
@@ -72,7 +72,7 @@ public sealed class CosmicClientTests
 
         httpTest.RespondWith("bang!", 500);
 
-        var client = new CosmicClient<CosmicBooks>(_configuration!, _mockLogger!, _resiliencePolicy!);
+        var client = new CosmicClient<CosmicBooks>(_configuration, _mockLogger, _resiliencePolicy);
 
         // act
         var act = async () => await client.GetAsync().ConfigureAwait(false);

--- a/src/Tests/Coding.Blog.UnitTests/Mappers/BookMapperTests.cs
+++ b/src/Tests/Coding.Blog.UnitTests/Mappers/BookMapperTests.cs
@@ -8,7 +8,7 @@ using NUnit.Framework;
 namespace Coding.Blog.UnitTests.Mappers;
 
 [TestFixture]
-public sealed class BookMapperTests
+internal sealed class BookMapperTests
 {
     [Test]
     public void Map_generates_expected_book()

--- a/src/Tests/Coding.Blog.UnitTests/Mappers/PostLinkerTests.cs
+++ b/src/Tests/Coding.Blog.UnitTests/Mappers/PostLinkerTests.cs
@@ -7,7 +7,7 @@ using NUnit.Framework;
 namespace Coding.Blog.UnitTests.Mappers;
 
 [TestFixture]
-public sealed class PostLinkerTests
+internal sealed class PostLinkerTests
 {
     [Test]
     public void PostLinker_links_expected_posts()

--- a/src/Tests/Coding.Blog.UnitTests/Mappers/PostMapperTests.cs
+++ b/src/Tests/Coding.Blog.UnitTests/Mappers/PostMapperTests.cs
@@ -10,9 +10,9 @@ using NUnit.Framework;
 namespace Coding.Blog.UnitTests.Mappers;
 
 [TestFixture]
-public sealed class PostMapperTests
+internal sealed class PostMapperTests
 {
-    private IReadTimeEstimator? _mockReadTimeEstimator;
+    private IReadTimeEstimator _mockReadTimeEstimator = default!;
 
     [SetUp]
     public void SetUp() => _mockReadTimeEstimator = Substitute.For<IReadTimeEstimator>();
@@ -21,7 +21,7 @@ public sealed class PostMapperTests
     public void Map_generates_expected_post()
     {
         // arrange
-        _mockReadTimeEstimator!
+        _mockReadTimeEstimator
             .Estimate(Arg.Any<string>())
             .Returns(TimeSpan.MaxValue);
 
@@ -68,7 +68,7 @@ public sealed class PostMapperTests
     public void Map_generates_expected_posts()
     {
         // arrange
-        _mockReadTimeEstimator!
+        _mockReadTimeEstimator
             .Estimate(Arg.Any<string>())
             .Returns(TimeSpan.MaxValue);
 

--- a/src/Tests/Coding.Blog.UnitTests/Services/BooksServiceTests.cs
+++ b/src/Tests/Coding.Blog.UnitTests/Services/BooksServiceTests.cs
@@ -13,10 +13,10 @@ using Grpc.Core.Testing;
 namespace Coding.Blog.UnitTests.Services;
 
 [TestFixture]
-public sealed class BooksServiceTests
+internal sealed class BooksServiceTests
 {
-    private ICosmicClient<CosmicBooks>? _mockCosmicBookClient;
-    private IMapper<CosmicBook, Book>? _mockBookMapper;
+    private ICosmicClient<CosmicBooks> _mockCosmicBookClient = default!;
+    private IMapper<CosmicBook, Book> _mockBookMapper = default!;
 
     [SetUp]
     public void SetUp()
@@ -40,7 +40,7 @@ public sealed class BooksServiceTests
             }
         );
 
-        _mockCosmicBookClient!
+        _mockCosmicBookClient
             .GetAsync()
             .Returns(mockCosmicBooksClientResponse);
 
@@ -53,7 +53,7 @@ public sealed class BooksServiceTests
             DatePublished = Timestamp.FromDateTime(mockDatePublished)
         });
 
-        _mockBookMapper!
+        _mockBookMapper
             .Map(mockCosmicBooksClientResponse.Books)
             .Returns(mockBookMapperResponse);
 
@@ -95,11 +95,11 @@ public sealed class BooksServiceTests
         // arrange
         var mockCosmicBooksClientResponse = new CosmicBooks(new List<CosmicBook>());
 
-        _mockCosmicBookClient!
+        _mockCosmicBookClient
             .GetAsync()
             .Returns(mockCosmicBooksClientResponse);
 
-        _mockBookMapper!
+        _mockBookMapper
             .Map(mockCosmicBooksClientResponse.Books)
             .Returns(new List<Book>());
 

--- a/src/Tests/Coding.Blog.UnitTests/Services/PostsServiceTests.cs
+++ b/src/Tests/Coding.Blog.UnitTests/Services/PostsServiceTests.cs
@@ -13,11 +13,11 @@ using Grpc.Core.Testing;
 namespace Coding.Blog.UnitTests.Services;
 
 [TestFixture]
-public sealed class PostsServiceTests
+internal sealed class PostsServiceTests
 {
-    private ICosmicClient<CosmicPosts>? _mockCosmicPostClient;
-    private IMapper<CosmicPost, Post>? _mockPostMapper;
-    private IPostLinker? _mockPostLinker;
+    private ICosmicClient<CosmicPosts> _mockCosmicPostClient = default!;
+    private IMapper<CosmicPost, Post> _mockPostMapper = default!;
+    private IPostLinker _mockPostLinker = default!;
 
     [SetUp]
     public void SetUp()
@@ -61,7 +61,7 @@ public sealed class PostsServiceTests
             }
         );
 
-        _mockCosmicPostClient!
+        _mockCosmicPostClient
             .GetAsync()
             .Returns(mockCosmicPostsClientResponse);
 
@@ -79,7 +79,7 @@ public sealed class PostsServiceTests
             }
         }).ToList();
 
-        _mockPostMapper!
+        _mockPostMapper
             .Map(mockCosmicPostsClientResponse.Posts)
             .Returns(mockPostMapperResponse);
 
@@ -89,7 +89,7 @@ public sealed class PostsServiceTests
             Previous = new Post()
         }).ToList();
 
-        _mockPostLinker!
+        _mockPostLinker
             .Link(mockPostMapperResponse)
             .Returns(mockPostLinkerResponse);
 
@@ -135,18 +135,18 @@ public sealed class PostsServiceTests
         // arrange
         var mockCosmicPostsClientResponse = new CosmicPosts(new List<CosmicPost>());
 
-        _mockCosmicPostClient!
+        _mockCosmicPostClient
             .GetAsync()
             .Returns(mockCosmicPostsClientResponse);
 
         // ReSharper disable once CollectionNeverUpdated.Local
         var mockPostMapperResponse = new List<Post>();
 
-        _mockPostMapper!
+        _mockPostMapper
             .Map(mockCosmicPostsClientResponse.Posts)
             .Returns(mockPostMapperResponse);
 
-        _mockPostLinker!
+        _mockPostLinker
             .Link(mockPostMapperResponse)
             .Returns(new List<Post>());
 

--- a/src/Tests/Coding.Blog.UnitTests/Utilities/ReadTimeEstimatorTests.cs
+++ b/src/Tests/Coding.Blog.UnitTests/Utilities/ReadTimeEstimatorTests.cs
@@ -6,15 +6,12 @@ using NUnit.Framework;
 namespace Coding.Blog.UnitTests.Utilities;
 
 [TestFixture]
-public sealed class ReadTimeEstimatorTests
+internal sealed class ReadTimeEstimatorTests
 {
-    private IStringSanitizer? _mockStringSanitizer;
+    private IStringSanitizer _mockStringSanitizer = default!;
 
     [SetUp]
-    public void SetUp()
-    {
-        _mockStringSanitizer = Substitute.For<IStringSanitizer>();
-    }
+    public void SetUp() => _mockStringSanitizer = Substitute.For<IStringSanitizer>();
 
     [Test]
     [TestCase(1, 1)]
@@ -25,7 +22,7 @@ public sealed class ReadTimeEstimatorTests
         // arrange
         var content = string.Join(' ', Enumerable.Range(0, wordCount).Select(_ => "hello"));
 
-        _mockStringSanitizer!
+        _mockStringSanitizer
             .Sanitize(content)
             .Returns(content);
 

--- a/src/Tests/Coding.Blog.UnitTests/Utilities/StringSanitizerTests.cs
+++ b/src/Tests/Coding.Blog.UnitTests/Utilities/StringSanitizerTests.cs
@@ -6,7 +6,7 @@ using NUnit.Framework;
 namespace Coding.Blog.UnitTests.Utilities;
 
 [TestFixture]
-public sealed class StringSanitizerTests
+internal sealed class StringSanitizerTests
 {
     [Test]
     public void StringSanitizer_generates_expected_string()
@@ -19,27 +19,36 @@ public sealed class StringSanitizerTests
         var sanitizedString = sanitizer.Sanitize(MarkdownString);
 
         // assert
-        sanitizedString.Should().Be(SanitizedString);
+        AssertEqualIgnoreNewLines(ExpectedSanitizedString, sanitizedString);
     }
 
-    private const string MarkdownString = @"
-# This is a header
+    public static void AssertEqualIgnoreNewLines(string expected, string actual)
+    {
+        var normalizedExpected = expected.Replace("\r\n", "\n", StringComparison.OrdinalIgnoreCase).Replace('\r', '\n');
+        var normalizedActual = actual.Replace("\r\n", "\n", StringComparison.OrdinalIgnoreCase).Replace('\r', '\n');
 
-Here is some other content with a [link](https://google.com).
+        normalizedExpected.Should().Be(normalizedActual);
+    }
 
-## Code example sub-header
+    private const string MarkdownString = """
+                                          # This is a header
 
-```
-var foo = new Bar();
-var bar = foo.Bar();
-```
-";
+                                          Here is some other content with a [link](https://google.com).
 
-    private const string SanitizedString = @"This is a header
-Here is some other content with a link.
-Code example sub-header
-var foo = new Bar();
-var bar = foo.Bar();
-";
+                                          ## Code example sub-header
 
+                                          ```
+                                          var foo = new Bar();
+                                          var bar = foo.Bar();
+                                          ```
+                                          """;
+
+    private const string ExpectedSanitizedString = """
+                                                   This is a header
+                                                   Here is some other content with a link.
+                                                   Code example sub-header
+                                                   var foo = new Bar();
+                                                   var bar = foo.Bar();
+
+                                                   """;
 }


### PR DESCRIPTION
- Make unit tests `internal`
- Remove trailing commas and related sniff
- Use block strings