### PR TITLE
General Cleanup

### DIFF
--- a/src/Coding.Blog/Coding.Blog.Client/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Coding.Blog/Coding.Blog.Client/Extensions/ServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@
 using Coding.Blog.Library.Options;
 using Coding.Blog.Library.Protos;
 using Coding.Blog.Library.Services;
+using Coding.Blog.Library.Utilities;
 using Grpc.Core;
 using Grpc.Net.Client.Configuration;
 using Grpc.Net.Client.Web;

--- a/src/Coding.Blog/Coding.Blog.Library/Mappers/PostProtoToPostMapper.cs
+++ b/src/Coding.Blog/Coding.Blog.Library/Mappers/PostProtoToPostMapper.cs
@@ -3,7 +3,7 @@ using PostProto = Coding.Blog.Library.Protos.Post;
 
 namespace Coding.Blog.Library.Mappers;
 
-public class PostProtoToPostMapper : BaseMapper<PostProto, Post>
+public sealed class PostProtoToPostMapper : BaseMapper<PostProto, Post>
 {
     public override Post Map(PostProto source) => new(
         source.Id,

--- a/src/Coding.Blog/Coding.Blog.Library/Records/CosmicProject.cs
+++ b/src/Coding.Blog/Coding.Blog.Library/Records/CosmicProject.cs
@@ -2,7 +2,7 @@
 
 namespace Coding.Blog.Library.Records;
 
-public record CosmicProject(
+public sealed record CosmicProject(
     [property: JsonPropertyName("title")] string Title,
     [property: JsonPropertyName("metadata")] CosmicProjectMetadata Metadata
 );

--- a/src/Coding.Blog/Coding.Blog.Library/Services/ClientPostsService.cs
+++ b/src/Coding.Blog/Coding.Blog.Library/Services/ClientPostsService.cs
@@ -1,11 +1,12 @@
 ﻿using Coding.Blog.Library.Mappers;
 using Coding.Blog.Library.Protos;
+using Coding.Blog.Library.Utilities;
 using Post = Coding.Blog.Library.Domain.Post;
 using PostProto = Coding.Blog.Library.Protos.Post;
 
 namespace Coding.Blog.Library.Services;
 
-public class ClientPostsService(
+public sealed class ClientPostsService(
     Posts.PostsClient postsClient,
     IMapper<PostProto, Post> postMapper,
     IPostLinker postLinker

--- a/src/Coding.Blog/Coding.Blog.Library/Services/PostsService.cs
+++ b/src/Coding.Blog/Coding.Blog.Library/Services/PostsService.cs
@@ -2,6 +2,7 @@
 using Coding.Blog.Library.Domain;
 using Coding.Blog.Library.Mappers;
 using Coding.Blog.Library.Records;
+using Coding.Blog.Library.Utilities;
 
 namespace Coding.Blog.Library.Services;
 

--- a/src/Coding.Blog/Coding.Blog.Library/Utilities/IPostLinker.cs
+++ b/src/Coding.Blog/Coding.Blog.Library/Utilities/IPostLinker.cs
@@ -1,6 +1,6 @@
 ﻿using Coding.Blog.Library.Domain;
 
-namespace Coding.Blog.Library.Mappers;
+namespace Coding.Blog.Library.Utilities;
 
 public interface IPostLinker
 {

--- a/src/Coding.Blog/Coding.Blog.Library/Utilities/IReadTimeEstimator.cs
+++ b/src/Coding.Blog/Coding.Blog.Library/Utilities/IReadTimeEstimator.cs
@@ -1,8 +1,4 @@
-﻿using System.Runtime.CompilerServices;
-
-[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
-
-namespace Coding.Blog.Library.Utilities;
+﻿namespace Coding.Blog.Library.Utilities;
 
 /// <summary>
 ///     Calculates estimated reading time.

--- a/src/Coding.Blog/Coding.Blog.Library/Utilities/PostLinker.cs
+++ b/src/Coding.Blog/Coding.Blog.Library/Utilities/PostLinker.cs
@@ -1,6 +1,6 @@
 ﻿using Coding.Blog.Library.Domain;
 
-namespace Coding.Blog.Library.Mappers;
+namespace Coding.Blog.Library.Utilities;
 
 public sealed class PostLinker : IPostLinker
 {


### PR DESCRIPTION
- Seal implementations where possible
- Move `IPostLinker` and `PostLinker` to utilities namespace