### PR TITLE
Persistent Posts Service

### DIFF
--- a/src/Coding.Blog/Coding.Blog.Client/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Coding.Blog/Coding.Blog.Client/Extensions/ServiceCollectionExtensions.cs
@@ -22,6 +22,7 @@ internal static class ServiceCollectionExtensions
         .AddSingleton<IMapper<PostProto, Post>, PostProtoToPostMapper>()
         .AddSingleton<IPostLinker, PostLinker>()
         .AddSingleton<IPostsService, ClientPostsService>()
+        .AddSingleton<IPersistentPostsService, PersistentPostsService>()
         .AddGrpc(configuration);
 
     private static IServiceCollection AddGrpc(this IServiceCollection services, IConfiguration configuration)

--- a/src/Coding.Blog/Coding.Blog.Client/Pages/Blog.razor
+++ b/src/Coding.Blog/Coding.Blog.Client/Pages/Blog.razor
@@ -57,40 +57,12 @@
 
         _persistingComponentStateSubscription = ApplicationState.RegisterOnPersisting(PersistData);
 
-        IDictionary<string, Post> posts = new Dictionary<string, Post>();
-
-        if (ApplicationState.TryTakeFromJson<IDictionary<string, Post>>(PostsKey, out var postsFromState))
-        {
-            posts = postsFromState ?? new Dictionary<string, Post>();
-            PostsContainer.Posts = posts;
-        }
-
-        if (!posts.Any())
-        {
-            if (PostsContainer.Posts.Any())
-            {
-                posts = PostsContainer.Posts;
-            }
-            else
-            {
-                posts = await GetPostsAsync();
-                PostsContainer.Posts = posts;
-            }
-        }
-
-        Posts = posts;
+        Posts = await PersistentPostsService.GetAsync(ApplicationState, PostsKey);
 
         if (!string.IsNullOrWhiteSpace(Search))
         {
             _search = Search;
         }
-    }
-
-    private async Task<IDictionary<string, Post>> GetPostsAsync()
-    {
-        var blogPosts = await PostsService.GetAsync();
-
-        return blogPosts.ToDictionary(post => post.Slug, post => post);
     }
 
     private IDictionary<string, Post> GetSearchedPosts(IDictionary<string, Post> posts)

--- a/src/Coding.Blog/Coding.Blog.Client/Pages/PostDetails.razor
+++ b/src/Coding.Blog/Coding.Blog.Client/Pages/PostDetails.razor
@@ -107,40 +107,12 @@
 
     private async Task RefreshPostAsync()
     {
-        IDictionary<string, Post> posts = new Dictionary<string, Post>();
-
-        if (ApplicationState.TryTakeFromJson<IDictionary<string, Post>>(PostsKey, out var postsFromState))
-        {
-            posts = postsFromState ?? new Dictionary<string, Post>();
-            PostsContainer.Posts = posts;
-        }
-
-        if (!posts.Any())
-        {
-            if (PostsContainer.Posts.Any())
-            {
-                posts = PostsContainer.Posts;
-            }
-            else
-            {
-                posts = await GetPostsAsync();
-                PostsContainer.Posts = posts;
-            }
-        }
-
-        Posts = posts;
+        Posts = await PersistentPostsService.GetAsync(ApplicationState, PostsKey);
 
         if (_selectedPost is null)
         {
             Posts.TryGetValue(Slug, out _selectedPost);
         }
-    }
-
-    private async Task<IDictionary<string, Post>> GetPostsAsync()
-    {
-        var posts = await PostsService.GetAsync();
-
-        return posts.ToDictionary(post => post.Slug, post => post);
     }
 
     private void NavigateToMain() => NavigationManager.NavigateTo("/blog");

--- a/src/Coding.Blog/Coding.Blog.Client/_Imports.razor
+++ b/src/Coding.Blog/Coding.Blog.Client/_Imports.razor
@@ -15,6 +15,7 @@
 @using Coding.Blog.Library.State
 
 @inject IPostsService PostsService
+@inject IPersistentPostsService PersistentPostsService
 @inject PersistentComponentState ApplicationState
 @inject IJSRuntime JavaScript
 @inject MarkdownPipeline MarkdownPipeline

--- a/src/Coding.Blog/Coding.Blog.Client/_Imports.razor
+++ b/src/Coding.Blog/Coding.Blog.Client/_Imports.razor
@@ -14,7 +14,6 @@
 @using Coding.Blog.Library.Domain
 @using Coding.Blog.Library.State
 
-@inject IPostsService PostsService
 @inject IPersistentPostsService PersistentPostsService
 @inject PersistentComponentState ApplicationState
 @inject IJSRuntime JavaScript

--- a/src/Coding.Blog/Coding.Blog.Library/Coding.Blog.Library.csproj
+++ b/src/Coding.Blog/Coding.Blog.Library/Coding.Blog.Library.csproj
@@ -20,6 +20,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="Polly.Caching.Memory" Version="3.0.2" />

--- a/src/Coding.Blog/Coding.Blog.Library/Services/IPersistentPostsService.cs
+++ b/src/Coding.Blog/Coding.Blog.Library/Services/IPersistentPostsService.cs
@@ -1,0 +1,9 @@
+﻿using Coding.Blog.Library.Domain;
+using Microsoft.AspNetCore.Components;
+
+namespace Coding.Blog.Library.Services;
+
+public interface IPersistentPostsService
+{
+    Task<IDictionary<string, Post>> GetAsync(PersistentComponentState applicationState, string stateKey);
+}

--- a/src/Coding.Blog/Coding.Blog.Library/Services/PersistentPostsService.cs
+++ b/src/Coding.Blog/Coding.Blog.Library/Services/PersistentPostsService.cs
@@ -1,0 +1,34 @@
+﻿using Coding.Blog.Library.Domain;
+using Coding.Blog.Library.State;
+using Microsoft.AspNetCore.Components;
+
+namespace Coding.Blog.Library.Services;
+
+public class PersistentPostsService(IPostsService postsService) : IPersistentPostsService
+{
+    public async Task<IDictionary<string, Post>> GetAsync(PersistentComponentState applicationState, string stateKey)
+    {
+        if (applicationState.TryTakeFromJson<IDictionary<string, Post>>(stateKey, out var postsFromState))
+        {
+            PostsState.Posts = postsFromState ?? new Dictionary<string, Post>(StringComparer.Ordinal);
+        }
+
+        if (PostsState.Posts.Any())
+        {
+            return PostsState.Posts;
+        }
+
+        PostsState.Posts = await GetPostsAsync().ConfigureAwait(false);
+
+        return PostsState.Posts;
+    }
+
+    private async Task<IDictionary<string, Post>> GetPostsAsync()
+    {
+        var posts = await postsService.GetAsync().ConfigureAwait(false);
+
+        return posts.ToDictionary(post => post.Slug, post => post, StringComparer.Ordinal);
+    }
+}
+
+

--- a/src/Coding.Blog/Coding.Blog.Library/Services/PersistentPostsService.cs
+++ b/src/Coding.Blog/Coding.Blog.Library/Services/PersistentPostsService.cs
@@ -30,5 +30,3 @@ public class PersistentPostsService(IPostsService postsService) : IPersistentPos
         return posts.ToDictionary(post => post.Slug, post => post, StringComparer.Ordinal);
     }
 }
-
-

--- a/src/Coding.Blog/Coding.Blog.Library/State/PostsState.cs
+++ b/src/Coding.Blog/Coding.Blog.Library/State/PostsState.cs
@@ -2,7 +2,7 @@
 
 namespace Coding.Blog.Library.State;
 
-public static class PostsContainer
+internal static class PostsState
 {
     public static IDictionary<string, Post> Posts { get; set; } = new Dictionary<string, Post>(StringComparer.Ordinal);
 }

--- a/src/Coding.Blog/Coding.Blog/Components/_Imports.razor
+++ b/src/Coding.Blog/Coding.Blog/Components/_Imports.razor
@@ -14,7 +14,6 @@
 @using Coding.Blog.Client.Components
 @using Coding.Blog.Library.Domain
 
-@inject IPostsService PostsService
 @inject IBooksService BooksService
 @inject IProjectsService ProjectsService
 @inject IJSRuntime JavaScript

--- a/src/Coding.Blog/Coding.Blog/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Coding.Blog/Coding.Blog/Extensions/ServiceCollectionExtensions.cs
@@ -93,7 +93,8 @@ internal static class ServiceCollectionExtensions
     private static IServiceCollection AddDomainServices(this IServiceCollection services) => services
         .AddSingleton<IPostsService, PostsService>()
         .AddSingleton<IBooksService, BooksService>()
-        .AddSingleton<IProjectsService, ProjectsService>();
+        .AddSingleton<IProjectsService, ProjectsService>()
+        .AddSingleton<IPersistentPostsService, PersistentPostsService>();
 
     private static IServiceCollection AddUtilities(this IServiceCollection services) => services
         .AddSingleton(_ => new MarkdownPipelineBuilder().UseAdvancedExtensions().UseColorCode().Build())


### PR DESCRIPTION
Clean up duplicate code by creating an `IPersistentPostsService` which retrieves blog posts from application state, or statically if available, then falling back to loading them in via service call.