### PR TITLE
More Mobile-Friendly Layout

### DIFF
--- a/src/Coding.Blog/Coding.Blog.Client/Pages/Blog.razor
+++ b/src/Coding.Blog/Coding.Blog.Client/Pages/Blog.razor
@@ -3,7 +3,7 @@
 @rendermode InteractiveAuto
 @implements IDisposable
 
-<div class="container mb-3">
+<div class="container-fluid mb-3">
     @if (Posts is null)
     {
         <LoadingSpinner/>
@@ -17,11 +17,11 @@
             @foreach (var (slug, post) in GetSearchedPosts(Posts))
             {
                 <div class="col-12 col-lg-4">
-                    <div class="card border-0 h-100 shadow">
+                    <div class="card rounded border-0 h-100 shadow">
                         <a href="@($"post/{slug}")">
-                            <img src=@post.Hero.ImgixUrl class="card-img-top post-image" alt="hero"/>
+                            <img src=@post.Hero.ImgixUrl class="card-img-top rounded" alt="hero"/>
                         </a>
-                        <div class="card-body d-flex flex-column">
+                        <div class="card-body rounded d-flex flex-column">
                             <h5 class="card-title">@post.Title</h5>
                             <h6 class="card-subtitle text-muted">@post.DatePublished.ToString("D", new CultureInfo("en-US")) · @post.ReadingTime.Minutes minute read</h6>
                             <p class="card-text mt-2">

--- a/src/Coding.Blog/Coding.Blog.Client/Pages/Blog.razor.css
+++ b/src/Coding.Blog/Coding.Blog.Client/Pages/Blog.razor.css
@@ -1,20 +1,11 @@
 ﻿.card {
     transition: transform 0.3s ease, box-shadow 0.3s ease;
-    border-radius: 0.5rem;
 }
 
     .card:hover {
         transform: translateY(-5px);
         box-shadow: 0 4px 15px rgba(0,0,0,0.2);
     }
-
-.card-body {
-    border-radius: 0.5rem;
-}
-
-.post-image {
-    border-radius: 0.5rem;
-}
 
 input[type=search]::-webkit-search-cancel-button {
     -webkit-appearance: searchfield-cancel-button;

--- a/src/Coding.Blog/Coding.Blog.Client/Pages/PostDetails.razor
+++ b/src/Coding.Blog/Coding.Blog.Client/Pages/PostDetails.razor
@@ -2,7 +2,7 @@
 @rendermode InteractiveAuto
 @implements IDisposable
 
-<div class="container mb-3">
+<div class="container-fluid mb-3">
     @if (Posts is not null && _selectedPost is null)
     {
         <div class="alert alert-secondary" role="alert">
@@ -17,7 +17,6 @@
         }
         else
         {
-            <div class="container">
                 <div class="row justify-content-center">
                     <div class="col col-auto">
                         <h1>@_selectedPost.Title</h1>
@@ -28,8 +27,7 @@
                         <p class="text-muted">@_selectedPost.DatePublished.ToString("D", new CultureInfo("en-US")) · @_selectedPost.ReadingTime.Minutes minute read</p>
                     </div>
                 </div>
-            </div>
-            <div class="container overflow-hidden">
+            <div class="overflow-hidden">
                 <div class="row justify-content-center">
                     <div class="col col-auto">
                         <img class="rounded mx-auto d-block img-fluid post-hero" src="@_selectedPost.Hero.ImgixUrl" alt="hero">

--- a/src/Coding.Blog/Coding.Blog/Components/Layout/MainLayout.razor
+++ b/src/Coding.Blog/Coding.Blog/Components/Layout/MainLayout.razor
@@ -6,7 +6,7 @@
     </div>
 
     <main>
-        <article class="content px-4">
+        <article class="content g-0 px-2">
             @Body
         </article>
     </main>

--- a/src/Coding.Blog/Coding.Blog/Components/Pages/About.razor
+++ b/src/Coding.Blog/Coding.Blog/Components/Pages/About.razor
@@ -1,6 +1,6 @@
 ﻿@page "/"
 
-<div class="container">
+<div class="container-fluid mb-3">
     <h1 class="text-center display-3">About</h1>
 
     <div class="row align-items-center">

--- a/src/Coding.Blog/Coding.Blog/Components/Pages/About.razor.css
+++ b/src/Coding.Blog/Coding.Blog/Components/Pages/About.razor.css
@@ -1,10 +1,4 @@
-﻿.container {
-    max-width: 960px;
-    margin: 0 auto;
-    padding: 2rem;
-}
-
-.text-center {
+﻿.text-center {
     text-align: center;
 }
 
@@ -51,7 +45,7 @@
 }
 
 .card {
-    padding: 20px;
+    padding: 10px;
     border-radius: 5px;
     box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
     margin-bottom: 20px;
@@ -59,31 +53,4 @@
 
 .hover-link {
     transition: color 0.3s;
-}
-
-.animated-typing {
-    overflow: hidden;
-    white-space: nowrap;
-    border-right: .15em solid;
-    animation: typing 4s steps(30, end), blink-caret .5s step-end infinite alternate;
-}
-
-@keyframes typing {
-    from {
-        width: 0;
-    }
-
-    to {
-        width: 100%;
-    }
-}
-
-@keyframes blink-caret {
-    from, to {
-        border-color: transparent;
-    }
-
-    50% {
-        border-color: inherit;
-    }
 }

--- a/src/Coding.Blog/Coding.Blog/Components/Pages/Projects.razor
+++ b/src/Coding.Blog/Coding.Blog/Components/Pages/Projects.razor
@@ -1,7 +1,7 @@
 ﻿@page "/projects"
 @attribute [StreamRendering]
 
-<div class="container mt-1">
+<div class="container-fluid mb-3">
     @if (_projects is null)
     {
         <LoadingSpinner/>

--- a/src/Coding.Blog/Coding.Blog/Components/Pages/Projects.razor.css
+++ b/src/Coding.Blog/Coding.Blog/Components/Pages/Projects.razor.css
@@ -9,8 +9,6 @@
     display: flex;
     flex-direction: row;
     margin-bottom: 1rem;
-
-
     transition: transform 0.3s ease, box-shadow 0.3s ease; /* Smooth transition for hover effect */
     border-radius: 0.5rem; /* Rounded corners for a softer look */
 }

--- a/src/Coding.Blog/Coding.Blog/Components/Pages/Reading.razor
+++ b/src/Coding.Blog/Coding.Blog/Components/Pages/Reading.razor
@@ -1,7 +1,7 @@
 ﻿@page "/reading"
 @attribute [StreamRendering]
 
-<div class="container mb-3">
+<div class="container-fluid mb-3">
     @if (Books is null)
     {
         <LoadingSpinner/>

--- a/src/Coding.Blog/Coding.Blog/wwwroot/app.css
+++ b/src/Coding.Blog/Coding.Blog/wwwroot/app.css
@@ -6,6 +6,8 @@ html, body {
 
 body {
     overflow-y: scroll;
+    min-width: 360px;
+    margin: 0 auto;
 }
 
 h1:focus {
@@ -99,3 +101,13 @@ h1:focus {
 .darker-border-checkbox.form-check-input {
     border-color: #929292;
 }
+
+@media (max-width: 640.98px) {
+    .card-body {
+        padding-left: 6px;
+        padding-right: 6px;
+        padding-top: 6px;
+        padding-bottom: 6px;
+    }
+}
+


### PR DESCRIPTION
- Swap from `container` to `container-fluid`
- Remove nested `container` usage
- Remove unused CSS
- Set `g-0` and `px-2` for overall layout
- Use media query to reduce `card-body` padding on smaller screens