### PR TITLE
Scrolling & Tagging Fixes

### DIFF
--- a/src/Coding.Blog/Coding.Blog.Client/Pages/About.razor
+++ b/src/Coding.Blog/Coding.Blog.Client/Pages/About.razor
@@ -49,11 +49,5 @@
 
 @code
 {
-    protected override async Task OnInitializedAsync()
-    {
-        if (OperatingSystem.IsBrowser())
-        {
-            await JavaScript.InvokeVoidAsync("resetScrollPosition");
-        }
-    }
+    protected override async Task OnAfterRenderAsync(bool firstRender) => await JavaScript.InvokeVoidAsync("resetScrollPosition");
 }

--- a/src/Coding.Blog/Coding.Blog.Client/Pages/Blog.razor
+++ b/src/Coding.Blog/Coding.Blog.Client/Pages/Blog.razor
@@ -60,11 +60,6 @@
 
     protected override async Task OnInitializedAsync()
     {
-        if (OperatingSystem.IsBrowser())
-        {
-            await JavaScript.InvokeVoidAsync("resetScrollPosition");
-        }
-
         _persistingComponentStateSubscription = ApplicationState.RegisterOnPersisting(PersistData);
 
         Posts = await PersistentPostsService.GetAsync(ApplicationState, PostsKey);
@@ -74,6 +69,15 @@
             _search = HttpUtility.UrlDecode(Search);
         }
     }
+
+    protected override Task OnParametersSetAsync()
+    {
+        _search = Search ?? string.Empty;
+
+        return Task.CompletedTask;
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender) => await JavaScript.InvokeVoidAsync("resetScrollPosition");
 
     private IDictionary<string, Post> GetSearchedPosts(IDictionary<string, Post> posts)
     {

--- a/src/Coding.Blog/Coding.Blog.Client/Pages/Blog.razor.css
+++ b/src/Coding.Blog/Coding.Blog.Client/Pages/Blog.razor.css
@@ -6,7 +6,3 @@
         transform: translateY(-5px);
         box-shadow: 0 4px 15px rgba(0,0,0,0.2);
     }
-
-input[type=search]::-webkit-search-cancel-button {
-    -webkit-appearance: searchfield-cancel-button;
-}

--- a/src/Coding.Blog/Coding.Blog.Client/Pages/PostDetails.razor
+++ b/src/Coding.Blog/Coding.Blog.Client/Pages/PostDetails.razor
@@ -117,11 +117,6 @@
 
     protected override async Task OnInitializedAsync()
     {
-        if (OperatingSystem.IsBrowser())
-        {
-            await JavaScript.InvokeVoidAsync("resetScrollPosition");
-        }
-
         _persistingComponentStateSubscription = ApplicationState.RegisterOnPersisting(PersistData);
 
         await RefreshPostAsync();
@@ -135,6 +130,8 @@
 
         Posts.TryGetValue(Slug, out _selectedPost);
     }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender) => await JavaScript.InvokeVoidAsync("resetScrollPosition");
 
     private void NavigateToMain() => NavigationManager.NavigateTo("");
 

--- a/src/Coding.Blog/Coding.Blog.Client/Pages/Projects.razor
+++ b/src/Coding.Blog/Coding.Blog.Client/Pages/Projects.razor
@@ -52,15 +52,12 @@
 
     protected override async Task OnInitializedAsync()
     {
-        if (OperatingSystem.IsBrowser())
-        {
-            await JavaScript.InvokeVoidAsync("resetScrollPosition");
-        }
-
         _persistingComponentStateSubscription = ApplicationState.RegisterOnPersisting(PersistData);
 
         _projects = await PersistentProjectsService.GetAsync(ApplicationState, ProjectsKey);
     }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender) => await JavaScript.InvokeVoidAsync("resetScrollPosition");
 
     private Task PersistData()
     {

--- a/src/Coding.Blog/Coding.Blog.Client/Pages/Reading.razor
+++ b/src/Coding.Blog/Coding.Blog.Client/Pages/Reading.razor
@@ -59,15 +59,12 @@
 
     protected override async Task OnInitializedAsync()
     {
-        if (OperatingSystem.IsBrowser())
-        {
-            await JavaScript.InvokeVoidAsync("resetScrollPosition");
-        }
-
         _persistingComponentStateSubscription = ApplicationState.RegisterOnPersisting(PersistData);
 
         Books = await PersistentBooksService.GetAsync(ApplicationState, BooksKey);
     }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender) => await JavaScript.InvokeVoidAsync("resetScrollPosition");
 
     private Task PersistData()
     {


### PR DESCRIPTION
- Fix "scroll to top" functionality by moving it from `OnInitializedAsync` to `OnAfterRenderAsync`
- Removed deprecated `searchfield-cancel-button` keyword
- Fix tag handling from blog landing page