### PR TITLE
Improve Code Syntax Highlighting

### DIFF
--- a/src/Coding.Blog/Coding.Blog.Client/Coding.Blog.Client.csproj
+++ b/src/Coding.Blog/Coding.Blog.Client/Coding.Blog.Client.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Grpc.Net.Client.Web" Version="2.60.0" />
     <PackageReference Include="Grpc.Net.ClientFactory" Version="2.60.0" />
     <PackageReference Include="Markdown.ColorCode" Version="2.1.0" />
-    <PackageReference Include="Meziantou.Analyzer" Version="2.0.133">
+    <PackageReference Include="Meziantou.Analyzer" Version="2.0.135">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Coding.Blog/Coding.Blog.Client/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Coding.Blog/Coding.Blog.Client/Extensions/ServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@ using Coding.Blog.Library.Options;
 using Coding.Blog.Library.Protos;
 using Coding.Blog.Library.Services;
 using Coding.Blog.Library.Utilities;
+using ColorCode;
 using Grpc.Core;
 using Grpc.Net.Client.Configuration;
 using Grpc.Net.Client.Web;
@@ -13,8 +14,8 @@ using Microsoft.Extensions.Options;
 using Book = Coding.Blog.Library.Domain.Book;
 using Post = Coding.Blog.Library.Domain.Post;
 using Project = Coding.Blog.Library.Domain.Project;
-using ProtoPost = Coding.Blog.Library.Protos.Post;
 using ProtoBook = Coding.Blog.Library.Protos.Book;
+using ProtoPost = Coding.Blog.Library.Protos.Post;
 using ProtoProject = Coding.Blog.Library.Protos.Project;
 
 namespace Coding.Blog.Client.Extensions;
@@ -22,7 +23,13 @@ namespace Coding.Blog.Client.Extensions;
 internal static class ServiceCollectionExtensions
 {
     public static IServiceCollection ConfigureServices(this IServiceCollection services, IConfiguration configuration) => services
-        .AddSingleton(_ => new MarkdownPipelineBuilder().UseAdvancedExtensions().UseColorCode().Build())
+        .AddSingleton(_ => new MarkdownPipelineBuilder()
+            .UseAdvancedExtensions()
+            .UseColorCode(
+                HtmlFormatterType.Style,
+                SyntaxHighlighting.Dark,
+                new List<ILanguage> { new CSharpOverride() })
+            .Build())
         .AddSingleton<IMapper<ProtoPost, Post>, ProtoPostToPostMapper>()
         .AddSingleton<IMapper<ProtoBook, Book>, ProtoBookToBookMapper>()
         .AddSingleton<IMapper<ProtoProject, Project>, ProtoProjectToProjectMapper>()

--- a/src/Coding.Blog/Coding.Blog.Library/Coding.Blog.Library.csproj
+++ b/src/Coding.Blog/Coding.Blog.Library/Coding.Blog.Library.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="ColorCode.Core" Version="2.0.15" />
     <PackageReference Include="Google.Protobuf" Version="3.25.1" />
     <PackageReference Include="Grpc.Net.Client" Version="2.60.0" />
     <PackageReference Include="Grpc.Tools" Version="2.60.0">
@@ -16,7 +17,7 @@
     </PackageReference>
     <PackageReference Include="Flurl.Http" Version="4.0.0" />
     <PackageReference Include="Markdig" Version="0.34.0" />
-    <PackageReference Include="Meziantou.Analyzer" Version="2.0.133">
+    <PackageReference Include="Meziantou.Analyzer" Version="2.0.135">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Coding.Blog/Coding.Blog.Library/Utilities/CSharpOverride.cs
+++ b/src/Coding.Blog/Coding.Blog.Library/Utilities/CSharpOverride.cs
@@ -1,0 +1,115 @@
+﻿using ColorCode;
+using ColorCode.Common;
+using System.Globalization;
+
+namespace Coding.Blog.Library.Utilities;
+
+/// <summary>
+///     Overrides the built-in C# language definition that ships with ColorCode-Universal. This augmented
+///     version adds support for differentiated syntax highlighting for classes and control keywords.
+/// </summary>
+public sealed class CSharpOverride : ILanguage
+{
+    public string Id => LanguageId.CSharp;
+
+    public string Name => "C#";
+
+    public string CssClassName => "csharp";
+
+    public string? FirstLinePattern => null;
+
+    public IList<LanguageRule> Rules =>
+        new List<LanguageRule>
+        {
+            new(
+                @"/\*([^*]|[\r\n]|(\*+([^*/]|[\r\n])))*\*+/",
+                new Dictionary<int, string>
+                {
+                    { 0, ScopeName.Comment }
+                }),
+            new(
+                @"(///)(?:\s*?(<[/a-zA-Z0-9\s""=]+>))*([^\r\n]*)",
+                new Dictionary<int, string>
+                {
+                    { 1, ScopeName.XmlDocTag },
+                    { 2, ScopeName.XmlDocTag },
+                    { 3, ScopeName.XmlDocComment }
+                }),
+            new(
+                @"(//.*?)\r?$",
+                new Dictionary<int, string>
+                {
+                    { 1, ScopeName.Comment }
+                }),
+            new(
+                @"'[^\n]*?(?<!\\)'",
+                new Dictionary<int, string>
+                {
+                    { 0, ScopeName.String }
+                }),
+            new(
+                @"(?s)@""(?:""""|.)*?""(?!"")",
+                new Dictionary<int, string>
+                {
+                    { 0, ScopeName.StringCSharpVerbatim }
+                }),
+            new(
+                @"(?s)(""[^\n]*?(?<!\\)"")",
+                new Dictionary<int, string>
+                {
+                    { 0, ScopeName.String }
+                }),
+            new(
+                @"\[(assembly|module|type|return|param|method|field|property|event):[^\]""]*(""[^\n]*?(?<!\\)"")?[^\]]*\]",
+                new Dictionary<int, string>
+                {
+                    { 1, ScopeName.Keyword },
+                    { 2, ScopeName.String }
+                }),
+            new(
+                @"^\s*(\#define|\#elif|\#else|\#endif|\#endregion|\#error|\#if|\#line|\#pragma|\#region|\#undef|\#warning).*?$",
+                new Dictionary<int, string>
+                {
+                    { 1, ScopeName.PreprocessorKeyword }
+                }),
+            new(
+                @"\b(public|protected|internal|private|sealed)?\s*(abstract\s+)?(static\s+)?(class)\s+([A-Za-z_][A-Za-z0-9_]*)",
+                new Dictionary<int, string>
+                {
+                    { 1, ScopeName.Keyword },
+                    { 2, ScopeName.Keyword },
+                    { 3, ScopeName.Keyword },
+                    { 4, ScopeName.Keyword },
+                    { 5, ScopeName.ClassName }
+                }),
+            new(
+                @"\b(break|case|catch|continue|do|else|finally|for|foreach|goto|if|in|return|switch|throw|try|while|yield)\b",
+                new Dictionary<int, string>
+                {
+                    { 0, ScopeName.ControlKeyword }
+                }),
+            new(
+                @"\b(abstract|as|ascending|base|bool|by|byte|char|checked|class|const|decimal|default|delegate|descending|double|dynamic|enum|equals|event|explicit|extern|false|fixed|float|from|get|group|implicit|int|into|interface|internal|is|join|let|lock|long|namespace|new|null|object|on|operator|orderby|out|override|params|partial|private|protected|public|readonly|ref|sbyte|sealed|select|set|short|sizeof|stackalloc|static|string|struct|this|throw|true|typeof|uint|ulong|unchecked|unsafe|ushort|using|var|virtual|void|volatile|where|async|await|warning|disable)\b",
+                new Dictionary<int, string>
+                {
+                    { 1, ScopeName.Keyword }
+                }),
+            new(
+                @"\b[0-9]{1,}\b",
+                new Dictionary<int, string>
+                {
+                    { 0, ScopeName.Number }
+                })
+        };
+
+    public bool HasAlias(string language) => language.ToLower(CultureInfo.InvariantCulture) switch
+    {
+        "cs" => true,
+        "c#" => true,
+        "csharp" => true,
+        "cake" => true,
+        _ => false
+    };
+
+    public override string ToString() => Name;
+}

--- a/src/Coding.Blog/Coding.Blog.Library/Utilities/SyntaxHighlighting.cs
+++ b/src/Coding.Blog/Coding.Blog.Library/Utilities/SyntaxHighlighting.cs
@@ -1,0 +1,400 @@
+﻿using ColorCode.Common;
+using ColorCode.Styling;
+
+namespace Coding.Blog.Library.Utilities;
+
+public static class SyntaxHighlighting
+{
+    public const string Blue = "#FF0000FF";
+    public const string White = "#FFFFFFFF";
+    public const string Black = "#FF000000";
+    public const string DullRed = "#FFA31515";
+    public const string Yellow = "#FFFFFF00";
+    public const string Green = "#FF008000";
+    public const string PowderBlue = "#FFB0E0E6";
+    public const string Teal = "#FF008080";
+    public const string Gray = "#FF808080";
+    public const string Navy = "#FF000080";
+    public const string OrangeRed = "#FFFF4500";
+    public const string Purple = "#FF800080";
+    public const string Red = "#FFFF0000";
+    public const string MediumTurqoise = "FF48D1CC";
+    public const string Magenta = "FFFF00FF";
+    public const string OliveDrab = "#FF6B8E23";
+    public const string DarkOliveGreen = "#FF556B2F";
+    public const string DarkCyan = "#FF008B8B";
+    public const string DarkOrange = "#FFFF8700";
+    public const string BrightGreen = "#FF00d700";
+    public const string BrightPurple = "#FFaf87ff";
+
+    private const string VSDarkBackground = "#FF1E1E1E";
+    private const string VSDarkPlainText = "#FFDADADA";
+    private const string VSDarkXMLDelimeter = "#FF808080";
+    private const string VSDarkXMLName = "#FF#E6E6E6";
+    private const string VSDarkXMLAttribute = "#FF92CAF4";
+    private const string VSDarkXAMLCData = "#FFC0D088";
+    private const string VSDarkXMLComment = "#FF608B4E";
+    private const string VSDarkComment = "#FF57A64A";
+    private const string VSDarkKeyword = "#FF569CD6";
+    private const string VSDarkControlKeyword = "#D8A0DF";
+    private const string VSDarkGray = "#FF9B9B9B";
+    private const string VSDarkNumber = "#FFB5CEA8";
+    private const string VSDarkClass = "#FF4EC9B0";
+    private const string VSDarkString = "#FFD69D85";
+
+    public static StyleDictionary Dark =>
+    [
+        new Style(ScopeName.PlainText)
+        {
+            Foreground = VSDarkPlainText,
+            Background = VSDarkBackground,
+            ReferenceName = "plainText"
+        },
+
+        new Style(ScopeName.HtmlServerSideScript)
+        {
+            Background = Yellow,
+            ReferenceName = "htmlServerSideScript"
+        },
+
+        new Style(ScopeName.HtmlComment)
+        {
+            Foreground = VSDarkComment,
+            ReferenceName = "htmlComment"
+        },
+
+        new Style(ScopeName.HtmlTagDelimiter)
+        {
+            Foreground = VSDarkKeyword,
+            ReferenceName = "htmlTagDelimiter"
+        },
+
+        new Style(ScopeName.HtmlElementName)
+        {
+            Foreground = DullRed,
+            ReferenceName = "htmlElementName"
+        },
+
+        new Style(ScopeName.HtmlAttributeName)
+        {
+            Foreground = Red,
+            ReferenceName = "htmlAttributeName"
+        },
+
+        new Style(ScopeName.HtmlAttributeValue)
+        {
+            Foreground = VSDarkKeyword,
+            ReferenceName = "htmlAttributeValue"
+        },
+
+        new Style(ScopeName.HtmlOperator)
+        {
+            Foreground = VSDarkKeyword,
+            ReferenceName = "htmlOperator"
+        },
+
+        new Style(ScopeName.Comment)
+        {
+            Foreground = VSDarkComment,
+            ReferenceName = "comment"
+        },
+
+        new Style(ScopeName.XmlDocTag)
+        {
+            Foreground = VSDarkXMLComment,
+            ReferenceName = "xmlDocTag"
+        },
+
+        new Style(ScopeName.XmlDocComment)
+        {
+            Foreground = VSDarkXMLComment,
+            ReferenceName = "xmlDocComment"
+        },
+
+        new Style(ScopeName.String)
+        {
+            Foreground = VSDarkString,
+            ReferenceName = "string"
+        },
+
+        new Style(ScopeName.StringCSharpVerbatim)
+        {
+            Foreground = VSDarkString,
+            ReferenceName = "stringCSharpVerbatim"
+        },
+
+        new Style(ScopeName.Keyword)
+        {
+            Foreground = VSDarkKeyword,
+            ReferenceName = "keyword"
+        },
+
+        new Style(ScopeName.PreprocessorKeyword)
+        {
+            Foreground = VSDarkKeyword,
+            ReferenceName = "preprocessorKeyword"
+        },
+
+        new Style(ScopeName.HtmlEntity)
+        {
+            Foreground = Red,
+            ReferenceName = "htmlEntity"
+        },
+
+        new Style(ScopeName.JsonKey)
+        {
+            Foreground = DarkOrange,
+            ReferenceName = "jsonKey"
+        },
+
+        new Style(ScopeName.JsonString)
+        {
+            Foreground = DarkCyan,
+            ReferenceName = "jsonString"
+        },
+
+        new Style(ScopeName.JsonNumber)
+        {
+            Foreground = BrightGreen,
+            ReferenceName = "jsonNumber"
+        },
+
+        new Style(ScopeName.JsonConst)
+        {
+            Foreground = BrightPurple,
+            ReferenceName = "jsonConst"
+        },
+
+        new Style(ScopeName.XmlAttribute)
+        {
+            Foreground = VSDarkXMLAttribute,
+            ReferenceName = "xmlAttribute"
+        },
+
+        new Style(ScopeName.XmlAttributeQuotes)
+        {
+            Foreground = VSDarkKeyword,
+            ReferenceName = "xmlAttributeQuotes"
+        },
+
+        new Style(ScopeName.XmlAttributeValue)
+        {
+            Foreground = VSDarkKeyword,
+            ReferenceName = "xmlAttributeValue"
+        },
+
+        new Style(ScopeName.XmlCDataSection)
+        {
+            Foreground = VSDarkXAMLCData,
+            ReferenceName = "xmlCDataSection"
+        },
+
+        new Style(ScopeName.XmlComment)
+        {
+            Foreground = VSDarkComment,
+            ReferenceName = "xmlComment"
+        },
+
+        new Style(ScopeName.XmlDelimiter)
+        {
+            Foreground = VSDarkXMLDelimeter,
+            ReferenceName = "xmlDelimiter"
+        },
+
+        new Style(ScopeName.XmlName)
+        {
+            Foreground = VSDarkXMLName,
+            ReferenceName = "xmlName"
+        },
+
+        new Style(ScopeName.ClassName)
+        {
+            Foreground = VSDarkClass,
+            ReferenceName = "className"
+        },
+
+        new Style(ScopeName.CssSelector)
+        {
+            Foreground = DullRed,
+            ReferenceName = "cssSelector"
+        },
+
+        new Style(ScopeName.CssPropertyName)
+        {
+            Foreground = Red,
+            ReferenceName = "cssPropertyName"
+        },
+
+        new Style(ScopeName.CssPropertyValue)
+        {
+            Foreground = VSDarkKeyword,
+            ReferenceName = "cssPropertyValue"
+        },
+
+        new Style(ScopeName.SqlSystemFunction)
+        {
+            Foreground = Magenta,
+            ReferenceName = "sqlSystemFunction"
+        },
+
+        new Style(ScopeName.PowerShellAttribute)
+        {
+            Foreground = PowderBlue,
+            ReferenceName = "powershellAttribute"
+        },
+
+        new Style(ScopeName.PowerShellOperator)
+        {
+            Foreground = VSDarkGray,
+            ReferenceName = "powershellOperator"
+        },
+
+        new Style(ScopeName.PowerShellType)
+        {
+            Foreground = Teal,
+            ReferenceName = "powershellType"
+        },
+
+        new Style(ScopeName.PowerShellVariable)
+        {
+            Foreground = OrangeRed,
+            ReferenceName = "powershellVariable"
+        },
+
+        new Style(ScopeName.PowerShellCommand)
+        {
+            Foreground = Yellow,
+            ReferenceName = "powershellCommand"
+        },
+
+        new Style(ScopeName.PowerShellParameter)
+        {
+            Foreground = VSDarkGray,
+            ReferenceName = "powershellParameter"
+        },
+
+
+        new Style(ScopeName.Type)
+        {
+            Foreground = Teal,
+            ReferenceName = "type"
+        },
+
+        new Style(ScopeName.TypeVariable)
+        {
+            Foreground = Teal,
+            Italic = true,
+            ReferenceName = "typeVariable"
+        },
+
+        new Style(ScopeName.NameSpace)
+        {
+            Foreground = Navy,
+            ReferenceName = "namespace"
+        },
+
+        new Style(ScopeName.Constructor)
+        {
+            Foreground = Purple,
+            ReferenceName = "constructor"
+        },
+
+        new Style(ScopeName.Predefined)
+        {
+            Foreground = Navy,
+            ReferenceName = "predefined"
+        },
+
+        new Style(ScopeName.PseudoKeyword)
+        {
+            Foreground = Navy,
+            ReferenceName = "pseudoKeyword"
+        },
+
+        new Style(ScopeName.StringEscape)
+        {
+            Foreground = VSDarkGray,
+            ReferenceName = "stringEscape"
+        },
+
+        new Style(ScopeName.ControlKeyword)
+        {
+            Foreground = VSDarkControlKeyword,
+            ReferenceName = "controlKeyword"
+        },
+
+        new Style(ScopeName.Number)
+        {
+            ReferenceName = "number",
+            Foreground = VSDarkNumber
+        },
+
+        new Style(ScopeName.Operator)
+        {
+            ReferenceName = "operator"
+        },
+
+        new Style(ScopeName.Delimiter)
+        {
+            ReferenceName = "delimiter"
+        },
+
+
+        new Style(ScopeName.MarkdownHeader)
+        {
+            Foreground = VSDarkKeyword,
+            Bold = true,
+            ReferenceName = "markdownHeader"
+        },
+
+        new Style(ScopeName.MarkdownCode)
+        {
+            Foreground = VSDarkString,
+            ReferenceName = "markdownCode"
+        },
+
+        new Style(ScopeName.MarkdownListItem)
+        {
+            Bold = true,
+            ReferenceName = "markdownListItem"
+        },
+
+        new Style(ScopeName.MarkdownEmph)
+        {
+            Italic = true,
+            ReferenceName = "italic"
+        },
+
+        new Style(ScopeName.MarkdownBold)
+        {
+            Bold = true,
+            ReferenceName = "bold"
+        },
+
+        new Style(ScopeName.BuiltinFunction)
+        {
+            Foreground = OliveDrab,
+            Bold = true,
+            ReferenceName = "builtinFunction"
+        },
+
+        new Style(ScopeName.BuiltinValue)
+        {
+            Foreground = DarkOliveGreen,
+            Bold = true,
+            ReferenceName = "builtinValue"
+        },
+
+        new Style(ScopeName.Attribute)
+        {
+            Foreground = DarkCyan,
+            Italic = true,
+            ReferenceName = "attribute"
+        },
+
+        new Style(ScopeName.SpecialCharacter)
+        {
+            ReferenceName = "specialChar"
+        }
+    ];
+}

--- a/src/Coding.Blog/Coding.Blog/Coding.Blog.csproj
+++ b/src/Coding.Blog/Coding.Blog/Coding.Blog.csproj
@@ -17,12 +17,12 @@
     <PackageReference Include="Blazorise.Icons.FontAwesome" Version="1.4.0" />
     <PackageReference Include="Grpc.AspNetCore" Version="2.60.0" />
     <PackageReference Include="Grpc.AspNetCore.Web" Version="2.60.0" />
-    <PackageReference Include="Meziantou.Analyzer" Version="2.0.133">
+    <PackageReference Include="Meziantou.Analyzer" Version="2.0.135">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.5" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.6" />
     <PackageReference Include="Quartz.Extensions.Hosting" Version="3.8.0" />
   </ItemGroup>
 

--- a/src/Coding.Blog/Coding.Blog/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Coding.Blog/Coding.Blog/Extensions/ServiceCollectionExtensions.cs
@@ -8,6 +8,7 @@ using Coding.Blog.Library.Records;
 using Coding.Blog.Library.Resilience;
 using Coding.Blog.Library.Services;
 using Coding.Blog.Library.Utilities;
+using ColorCode;
 using Markdig;
 using Markdown.ColorCode;
 using Microsoft.AspNetCore.HttpOverrides;
@@ -104,7 +105,13 @@ internal static class ServiceCollectionExtensions
         .AddSingleton<IPersistentService<IList<Project>>, PersistentProjectsService>();
 
     private static IServiceCollection AddUtilities(this IServiceCollection services) => services
-        .AddSingleton(_ => new MarkdownPipelineBuilder().UseAdvancedExtensions().UseColorCode().Build())
+        .AddSingleton(_ => new MarkdownPipelineBuilder()
+            .UseAdvancedExtensions()
+            .UseColorCode(
+                HtmlFormatterType.Style,
+                SyntaxHighlighting.Dark,
+                new List<ILanguage> { new CSharpOverride() })
+            .Build())
         .AddSingleton<IStringSanitizer, StringSanitizer>()
         .AddSingleton<IPostLinker, PostLinker>()
         .AddSingleton<IReadTimeEstimator, ReadTimeEstimator>();

--- a/src/Coding.Blog/Coding.Blog/wwwroot/app.css
+++ b/src/Coding.Blog/Coding.Blog/wwwroot/app.css
@@ -8,6 +8,14 @@ body {
     margin: 0 auto;
 }
 
+pre {
+    padding: 1rem !important;
+    border: 1px solid #dee2e6 !important;
+    border-radius: .25rem !important;
+    border-color: #00bc8c !important;
+}
+
+
 h1:focus {
     outline: none;
 }


### PR DESCRIPTION
- Add CSS for `pre` elements, adding borders and padding
- Implement custom language for C#-flavored markdown code block colorization
  - Differentiate class names
  - Differentiate control keywords from others
- Implement custom style dictionary for markdown code block colorization