### PR TITLE
Code Organization

### DIFF
--- a/src/Coding.Blog/Coding.Blog.Client/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Coding.Blog/Coding.Blog.Client/Extensions/ServiceCollectionExtensions.cs
@@ -1,4 +1,4 @@
-﻿using Coding.Blog.Library.Adapters;
+﻿using Coding.Blog.Library.Clients;
 using Coding.Blog.Library.Options;
 using Coding.Blog.Library.Protos;
 using Coding.Blog.Library.Services;
@@ -34,9 +34,9 @@ internal static class ServiceCollectionExtensions
         .AddSingleton<IPostLinker, PostLinker>()
         .AddSingleton<IStringSanitizer, StringSanitizer>()
         .AddSingleton<IReadTimeEstimator, ReadTimeEstimator>()
-        .AddSingleton<IProtoClientAdapter<ProtoPost>, PostsClientAdapter>()
-        .AddSingleton<IProtoClientAdapter<ProtoBook>, BooksClientAdapter>()
-        .AddSingleton<IProtoClientAdapter<ProtoProject>, ProjectsClientAdapter>()
+        .AddSingleton<IProtoClient<ProtoPost>, PostsClient>()
+        .AddSingleton<IProtoClient<ProtoBook>, BooksClient>()
+        .AddSingleton<IProtoClient<ProtoProject>, ProjectsClient>()
         .AddSingleton<IBlogService<Post>, ClientBlogService<ProtoPost, Post>>()
         .AddSingleton<IBlogService<Book>, ClientBlogService<ProtoBook, Book>>()
         .AddSingleton<IBlogService<Project>, ClientBlogService<ProtoProject, Project>>()

--- a/src/Coding.Blog/Coding.Blog.Library/Clients/BooksClient.cs
+++ b/src/Coding.Blog/Coding.Blog.Library/Clients/BooksClient.cs
@@ -1,8 +1,8 @@
 ﻿using Coding.Blog.Library.Protos;
 
-namespace Coding.Blog.Library.Adapters;
+namespace Coding.Blog.Library.Clients;
 
-public sealed class BooksClientAdapter(Books.BooksClient booksClient) : IProtoClientAdapter<Book>
+public sealed class BooksClient(Books.BooksClient booksClient) : IProtoClient<Book>
 {
     public async Task<IEnumerable<Book>> GetAsync()
     {

--- a/src/Coding.Blog/Coding.Blog.Library/Clients/CosmicClient.cs
+++ b/src/Coding.Blog/Coding.Blog.Library/Clients/CosmicClient.cs
@@ -1,5 +1,5 @@
-﻿using Coding.Blog.Library.Options;
-using Coding.Blog.Library.Records;
+﻿using Coding.Blog.Library.DataTransfer;
+using Coding.Blog.Library.Options;
 using Flurl;
 using Flurl.Http;
 using Microsoft.Extensions.Logging;

--- a/src/Coding.Blog/Coding.Blog.Library/Clients/CosmicRequestRegistry.cs
+++ b/src/Coding.Blog/Coding.Blog.Library/Clients/CosmicRequestRegistry.cs
@@ -1,4 +1,4 @@
-﻿using Coding.Blog.Library.Records;
+﻿using Coding.Blog.Library.DataTransfer;
 
 namespace Coding.Blog.Library.Clients;
 

--- a/src/Coding.Blog/Coding.Blog.Library/Clients/IProtoClient.cs
+++ b/src/Coding.Blog/Coding.Blog.Library/Clients/IProtoClient.cs
@@ -1,11 +1,11 @@
-﻿namespace Coding.Blog.Library.Adapters;
+﻿namespace Coding.Blog.Library.Clients;
 
 /// <summary>
-///     An interface which adapts various Protobuf clients to a common interface. This is needed
+///     An interface which adapts various Protobuf clients to a common API. This is needed
 ///     because Protobuf clients aren't generic and can't be forced to implement a common interface.
 /// </summary>
 /// <typeparam name="TProtoObject"></typeparam>
-public interface IProtoClientAdapter<TProtoObject>
+public interface IProtoClient<TProtoObject>
 {
     Task<IEnumerable<TProtoObject>> GetAsync();
 }

--- a/src/Coding.Blog/Coding.Blog.Library/Clients/PostsClient.cs
+++ b/src/Coding.Blog/Coding.Blog.Library/Clients/PostsClient.cs
@@ -1,8 +1,8 @@
 ﻿using Coding.Blog.Library.Protos;
 
-namespace Coding.Blog.Library.Adapters;
+namespace Coding.Blog.Library.Clients;
 
-public sealed class PostsClientAdapter(Posts.PostsClient postsClient) : IProtoClientAdapter<Post>
+public sealed class PostsClient(Posts.PostsClient postsClient) : IProtoClient<Post>
 {
     public async Task<IEnumerable<Post>> GetAsync()
     {

--- a/src/Coding.Blog/Coding.Blog.Library/Clients/ProjectsClient.cs
+++ b/src/Coding.Blog/Coding.Blog.Library/Clients/ProjectsClient.cs
@@ -1,8 +1,8 @@
 ﻿using Coding.Blog.Library.Protos;
 
-namespace Coding.Blog.Library.Adapters;
+namespace Coding.Blog.Library.Clients;
 
-public sealed class ProjectsClientAdapter(Projects.ProjectsClient projectsClient) : IProtoClientAdapter<Project>
+public sealed class ProjectsClient(Projects.ProjectsClient projectsClient) : IProtoClient<Project>
 {
     public async Task<IEnumerable<Project>> GetAsync()
     {

--- a/src/Coding.Blog/Coding.Blog.Library/DataTransfer/CosmicBook.cs
+++ b/src/Coding.Blog/Coding.Blog.Library/DataTransfer/CosmicBook.cs
@@ -1,6 +1,6 @@
 ﻿using System.Text.Json.Serialization;
 
-namespace Coding.Blog.Library.Records;
+namespace Coding.Blog.Library.DataTransfer;
 
 public sealed record CosmicBook(
     [property: JsonPropertyName("title")] string Title,

--- a/src/Coding.Blog/Coding.Blog.Library/DataTransfer/CosmicBookMetadata.cs
+++ b/src/Coding.Blog/Coding.Blog.Library/DataTransfer/CosmicBookMetadata.cs
@@ -1,6 +1,6 @@
 ﻿using System.Text.Json.Serialization;
 
-namespace Coding.Blog.Library.Records;
+namespace Coding.Blog.Library.DataTransfer;
 
 public sealed record CosmicBookMetadata(
     [property: JsonPropertyName("purchase_url")] string PurchaseUrl,

--- a/src/Coding.Blog/Coding.Blog.Library/DataTransfer/CosmicCollection.cs
+++ b/src/Coding.Blog/Coding.Blog.Library/DataTransfer/CosmicCollection.cs
@@ -1,6 +1,6 @@
 ﻿using System.Text.Json.Serialization;
 
-namespace Coding.Blog.Library.Records;
+namespace Coding.Blog.Library.DataTransfer;
 
 public sealed record CosmicCollection<T>(
     [property: JsonPropertyName("objects")] IEnumerable<T> Objects

--- a/src/Coding.Blog/Coding.Blog.Library/DataTransfer/CosmicImage.cs
+++ b/src/Coding.Blog/Coding.Blog.Library/DataTransfer/CosmicImage.cs
@@ -1,6 +1,6 @@
 ﻿using System.Text.Json.Serialization;
 
-namespace Coding.Blog.Library.Records;
+namespace Coding.Blog.Library.DataTransfer;
 
 public sealed record CosmicImage(
     [property: JsonPropertyName("url")] string Url,

--- a/src/Coding.Blog/Coding.Blog.Library/DataTransfer/CosmicPost.cs
+++ b/src/Coding.Blog/Coding.Blog.Library/DataTransfer/CosmicPost.cs
@@ -1,6 +1,6 @@
 ﻿using System.Text.Json.Serialization;
 
-namespace Coding.Blog.Library.Records;
+namespace Coding.Blog.Library.DataTransfer;
 
 public sealed record CosmicPost(
     [property: JsonPropertyName("id")] string Id,

--- a/src/Coding.Blog/Coding.Blog.Library/DataTransfer/CosmicPostMetadata.cs
+++ b/src/Coding.Blog/Coding.Blog.Library/DataTransfer/CosmicPostMetadata.cs
@@ -1,6 +1,6 @@
 ﻿using System.Text.Json.Serialization;
 
-namespace Coding.Blog.Library.Records;
+namespace Coding.Blog.Library.DataTransfer;
 
 public sealed record CosmicPostMetadata(
     [property: JsonPropertyName("hero")] CosmicImage Image,

--- a/src/Coding.Blog/Coding.Blog.Library/DataTransfer/CosmicProject.cs
+++ b/src/Coding.Blog/Coding.Blog.Library/DataTransfer/CosmicProject.cs
@@ -1,6 +1,6 @@
 ﻿using System.Text.Json.Serialization;
 
-namespace Coding.Blog.Library.Records;
+namespace Coding.Blog.Library.DataTransfer;
 
 public sealed record CosmicProject(
     [property: JsonPropertyName("title")] string Title,

--- a/src/Coding.Blog/Coding.Blog.Library/DataTransfer/CosmicProjectMetadata.cs
+++ b/src/Coding.Blog/Coding.Blog.Library/DataTransfer/CosmicProjectMetadata.cs
@@ -1,6 +1,6 @@
 ﻿using System.Text.Json.Serialization;
 
-namespace Coding.Blog.Library.Records;
+namespace Coding.Blog.Library.DataTransfer;
 
 public sealed record CosmicProjectMetadata(
     [property: JsonPropertyName("description")] string Description,

--- a/src/Coding.Blog/Coding.Blog.Library/Services/BooksService.cs
+++ b/src/Coding.Blog/Coding.Blog.Library/Services/BooksService.cs
@@ -1,6 +1,6 @@
 ﻿using Coding.Blog.Library.Clients;
+using Coding.Blog.Library.DataTransfer;
 using Coding.Blog.Library.Protos;
-using Coding.Blog.Library.Records;
 using Coding.Blog.Library.Utilities;
 using Grpc.Core;
 

--- a/src/Coding.Blog/Coding.Blog.Library/Services/ClientBlogService.cs
+++ b/src/Coding.Blog/Coding.Blog.Library/Services/ClientBlogService.cs
@@ -1,9 +1,9 @@
-﻿using Coding.Blog.Library.Adapters;
+﻿using Coding.Blog.Library.Clients;
 using Coding.Blog.Library.Utilities;
 
 namespace Coding.Blog.Library.Services;
 
-public sealed class ClientBlogService<TProtoObject, TDomainObject>(IProtoClientAdapter<TProtoObject> client, IMapper mapper) : IBlogService<TDomainObject>
+public sealed class ClientBlogService<TProtoObject, TDomainObject>(IProtoClient<TProtoObject> client, IMapper mapper) : IBlogService<TDomainObject>
 {
     public async Task<IEnumerable<TDomainObject>> GetAsync()
     {

--- a/src/Coding.Blog/Coding.Blog.Library/Services/PostsService.cs
+++ b/src/Coding.Blog/Coding.Blog.Library/Services/PostsService.cs
@@ -1,6 +1,6 @@
 ﻿using Coding.Blog.Library.Clients;
+using Coding.Blog.Library.DataTransfer;
 using Coding.Blog.Library.Protos;
-using Coding.Blog.Library.Records;
 using Coding.Blog.Library.Utilities;
 using Grpc.Core;
 

--- a/src/Coding.Blog/Coding.Blog.Library/Services/ProjectsService.cs
+++ b/src/Coding.Blog/Coding.Blog.Library/Services/ProjectsService.cs
@@ -1,6 +1,6 @@
 ﻿using Coding.Blog.Library.Clients;
+using Coding.Blog.Library.DataTransfer;
 using Coding.Blog.Library.Protos;
-using Coding.Blog.Library.Records;
 using Coding.Blog.Library.Utilities;
 using Grpc.Core;
 

--- a/src/Coding.Blog/Coding.Blog.Library/Utilities/Mapper.cs
+++ b/src/Coding.Blog/Coding.Blog.Library/Utilities/Mapper.cs
@@ -1,4 +1,4 @@
-﻿using Coding.Blog.Library.Records;
+﻿using Coding.Blog.Library.DataTransfer;
 using Google.Protobuf.WellKnownTypes;
 using Riok.Mapperly.Abstractions;
 using Book = Coding.Blog.Library.Domain.Book;

--- a/src/Coding.Blog/Coding.Blog.Library/Utilities/ResiliencePolicyBuilder.cs
+++ b/src/Coding.Blog/Coding.Blog.Library/Utilities/ResiliencePolicyBuilder.cs
@@ -4,7 +4,7 @@ using Polly;
 using Polly.Caching.Memory;
 using Polly.Contrib.WaitAndRetry;
 
-namespace Coding.Blog.Library.Resilience;
+namespace Coding.Blog.Library.Utilities;
 
 /// <summary>
 ///     Bundles the common resilience policies that I'd like to have in place at the

--- a/src/Coding.Blog/Coding.Blog/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Coding.Blog/Coding.Blog/Extensions/ServiceCollectionExtensions.cs
@@ -1,10 +1,9 @@
 ﻿using Blazorise;
 using Blazorise.Icons.FontAwesome;
 using Coding.Blog.Library.Clients;
+using Coding.Blog.Library.DataTransfer;
 using Coding.Blog.Library.Jobs;
 using Coding.Blog.Library.Options;
-using Coding.Blog.Library.Records;
-using Coding.Blog.Library.Resilience;
 using Coding.Blog.Library.Services;
 using Coding.Blog.Library.Utilities;
 using ColorCode;

--- a/tests/Coding.Blog.Tests/Utilities/MapperTests.cs
+++ b/tests/Coding.Blog.Tests/Utilities/MapperTests.cs
@@ -1,5 +1,5 @@
-﻿using Coding.Blog.Library.Protos;
-using Coding.Blog.Library.Records;
+﻿using Coding.Blog.Library.DataTransfer;
+using Coding.Blog.Library.Protos;
 using Coding.Blog.Library.Utilities;
 using FluentAssertions;
 using Google.Protobuf.WellKnownTypes;


### PR DESCRIPTION
- Move "Records" to "DataTransfer" namespace to better represent what they are
- Move Protobuf client adapters to "Clients" namespace
