### PR TITLE
Better Giscus Handling while Globally InteractiveAuto

### DIFF
--- a/src/Coding.Blog/Coding.Blog.Client/Pages/About.razor
+++ b/src/Coding.Blog/Coding.Blog.Client/Pages/About.razor
@@ -1,5 +1,4 @@
 ﻿@page "/about"
-@rendermode InteractiveAuto
 
 <PageTitle>Will Baldoumas | About</PageTitle>
 

--- a/src/Coding.Blog/Coding.Blog.Client/Pages/Blog.razor
+++ b/src/Coding.Blog/Coding.Blog.Client/Pages/Blog.razor
@@ -1,7 +1,6 @@
 ﻿@page "/"
 @page "/search"
 @implements IDisposable
-@rendermode InteractiveAuto
 
 <PageTitle>Will Baldoumas | Blog</PageTitle>
 
@@ -10,11 +9,7 @@
 </HeadContent>
 
 <div class="container mb-3">
-    @if (Posts is null)
-    {
-        <LoadingSpinner/>
-    }
-    else
+    @if (Posts is not null)
     {
         <div class="text-center mb-3">
             <input type="search" class="form-control rounded" placeholder="Search..." aria-label="search" aria-describedby="search-button" value="@query" @oninput="HandleSearchInput">

--- a/src/Coding.Blog/Coding.Blog.Client/Pages/PostDetails.razor
+++ b/src/Coding.Blog/Coding.Blog.Client/Pages/PostDetails.razor
@@ -1,6 +1,5 @@
 ﻿@page "/post/{Slug}"
 @implements IDisposable
-@rendermode InteractiveAuto
 
 <PageTitle>Will Baldoumas | @Title</PageTitle>
 
@@ -17,11 +16,7 @@
     }
     else
     {
-        @if (_selectedPost is null)
-        {
-            <LoadingSpinner/>
-        }
-        else
+        @if (_selectedPost is not null)
         {
             <div class="row justify-content-center">
                 <div class="col col-auto">
@@ -76,7 +71,7 @@
                 </div>
                 <div class="row justify-content-center mt-3">
                     <div class="card shadow-sm rounded">
-                        <div class="card-body rounded">
+                        <div class="card-body rounded giscus-container">
                             <script src="https://giscus.app/client.js"
                                     data-repo="wbaldoumas/coding-blog"
                                     data-repo-id="MDEwOlJlcG9zaXRvcnk0MDE1MDQwMDY="
@@ -131,7 +126,11 @@
         _selectedPost = Posts.FirstOrDefault(post => post.Slug == Slug);
     }
 
-    protected override async Task OnAfterRenderAsync(bool firstRender) => await JSInteropService.ResetScrollPositionAsync();
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        await JSInteropService.ResetScrollPositionAsync();
+        await JSInteropService.LoadGiscusAsync();
+    }
 
     private Task PersistData()
     {

--- a/src/Coding.Blog/Coding.Blog.Client/Pages/Projects.razor
+++ b/src/Coding.Blog/Coding.Blog.Client/Pages/Projects.razor
@@ -1,6 +1,5 @@
 ﻿@page "/projects"
 @implements IDisposable
-@rendermode InteractiveAuto
 
 <PageTitle>Will Baldoumas | Projects</PageTitle>
 
@@ -9,11 +8,7 @@
 </HeadContent>
 
 <div class="container mb-3">
-    @if (_projects is null)
-    {
-        <LoadingSpinner/>
-    }
-    else
+    @if (_projects is not null)
     {
         @if (!_projects.Any())
         {

--- a/src/Coding.Blog/Coding.Blog.Client/Pages/Reading.razor
+++ b/src/Coding.Blog/Coding.Blog.Client/Pages/Reading.razor
@@ -1,6 +1,5 @@
 ﻿@page "/reading"
 @implements IDisposable
-@rendermode InteractiveAuto
 
 <PageTitle>Will Baldoumas | Reading Recommendations</PageTitle>
 
@@ -9,11 +8,7 @@
 </HeadContent>
 
 <div class="container mb-3">
-    @if (Books is null)
-    {
-        <LoadingSpinner/>
-    }
-    else
+    @if (Books is not null)
     {
         @if (!Books.Any())
         {

--- a/src/Coding.Blog/Coding.Blog.Client/Services/IJSInteropService.cs
+++ b/src/Coding.Blog/Coding.Blog.Client/Services/IJSInteropService.cs
@@ -3,4 +3,12 @@
 public interface IJSInteropService
 {
     ValueTask ResetScrollPositionAsync();
+
+    /// <summary>
+    ///     This is a hack to make Giscus work nicely with a Blazor SPA. It's a workaround for the issue described
+    ///     here: <see href="https://github.com/giscus/giscus/issues/357"/>, until a better solution within Blazor
+    ///     is found, potentially implemented in <see href="https://github.com/Jisu-Woniu/giscus-blazor"/>.
+    /// </summary>
+    /// <returns> A <see cref="ValueTask"/> representing the asynchronous operation. </returns>
+    ValueTask LoadGiscusAsync();
 }

--- a/src/Coding.Blog/Coding.Blog.Client/Services/JSInteropService.cs
+++ b/src/Coding.Blog/Coding.Blog.Client/Services/JSInteropService.cs
@@ -5,4 +5,10 @@ namespace Coding.Blog.Client.Services;
 public sealed class JSInteropService(IJSRuntime jsRuntime) : IJSInteropService
 {
     public ValueTask ResetScrollPositionAsync() => jsRuntime.InvokeVoidAsync("resetScrollPosition");
+
+    public async ValueTask LoadGiscusAsync()
+    {
+        await jsRuntime.InvokeVoidAsync("removeGiscusFrame").ConfigureAwait(false);
+        await jsRuntime.InvokeVoidAsync("addGiscusFrame").ConfigureAwait(false);
+    }
 }

--- a/src/Coding.Blog/Coding.Blog/Components/App.razor
+++ b/src/Coding.Blog/Coding.Blog/Components/App.razor
@@ -10,15 +10,58 @@
     <link rel="stylesheet" href="Coding.Blog.styles.css"/>
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v6.5.1/css/all.css">
     <link rel="icon" type="image/png" href="favicon.ico"/>
-    <HeadOutlet />
+    <HeadOutlet @rendermode="@InteractiveAuto" />
 </head>
 
 <body>
-    <Routes />
+    <Routes @rendermode="@InteractiveAuto" />
     <script src="_framework/blazor.web.js"></script>
     <script type="text/javascript">
         function resetScrollPosition() {
             setTimeout(function () { window.scrollTo(0, 1); }, 1);
+        }
+    </script>
+    <script type="text/javascript">
+        function removeGiscusFrame() {
+            var giscusFrame = document.querySelector('iframe.giscus-frame');
+
+            if (giscusFrame) {
+                giscusFrame.remove();
+            }
+        }
+    </script>
+    <script type="text/javascript">
+        function addGiscusFrame() {
+            var giscusScript = document.querySelector('script.giscus-script');
+
+            if (giscusScript) {
+                giscusScript.remove();
+            }
+
+            var giscusContainer = document.querySelector('div.giscus-container');
+
+            if (giscusContainer) {
+                var giscusScript = document.createElement('script');
+
+                giscusScript.setAttribute('src', 'https://giscus.app/client.js');
+                giscusScript.setAttribute('data-repo', 'wbaldoumas/coding-blog');
+                giscusScript.setAttribute('data-repo-id', 'MDEwOlJlcG9zaXRvcnk0MDE1MDQwMDY=');
+                giscusScript.setAttribute('data-category', 'Announcements');
+                giscusScript.setAttribute('data-category-id', 'DIC_kwDOF-53Bs4CcJes');
+                giscusScript.setAttribute('data-mapping', 'pathname');
+                giscusScript.setAttribute('data-strict', '1');
+                giscusScript.setAttribute('data-reactions-enabled', '1');
+                giscusScript.setAttribute('data-emit-metadata', '0');
+                giscusScript.setAttribute('data-input-position', 'top');
+                giscusScript.setAttribute('data-theme', 'dark');
+                giscusScript.setAttribute('data-lang', 'en');
+                giscusScript.setAttribute('data-loading', 'lazy');
+                giscusScript.setAttribute('crossorigin', 'anonymous');
+                giscusScript.setAttribute('async', '');
+                giscusScript.classList.add('giscus-script');
+
+                giscusContainer.appendChild(giscusScript);
+            }
         }
     </script>
     <persist-component-state/>


### PR DESCRIPTION
- Reintroduce InteractiveAuto render mode globally
- Remove loading spinners, since the app loads so quickly
- Address previous issue that was happening when global InteractiveAuto mode was enabled, where Giscus was not loading the correct discussions for each post (see the issue [here](https://github.com/giscus/giscus/issues/357) describing how this problem occurs on SPAs). This workaround works by fully unloading and reloading the Giscus frame, which while brittle, works well.