### PR TITLE
Fix RSS Feed

### DIFF
--- a/src/Coding.Blog/Coding.Blog/Controllers/RssFeedController.cs
+++ b/src/Coding.Blog/Coding.Blog/Controllers/RssFeedController.cs
@@ -6,7 +6,7 @@ using System.Xml;
 
 namespace Coding.Blog.Controllers;
 
-internal sealed class RssFeedController(ISyndicationFeedService syndicationFeedService) : ControllerBase
+public sealed class RssFeedController(ISyndicationFeedService syndicationFeedService) : ControllerBase
 {
     [HttpGet]
     [Route("feed.rss")]

--- a/src/Coding.Blog/Coding.Blog/Services/ISyndicationFeedService.cs
+++ b/src/Coding.Blog/Coding.Blog/Services/ISyndicationFeedService.cs
@@ -2,7 +2,7 @@
 
 namespace Coding.Blog.Services;
 
-internal interface ISyndicationFeedService
+public interface ISyndicationFeedService
 {
     Task<SyndicationFeed> GetSyndicationFeed(string syndicationUrl);
 }


### PR DESCRIPTION
Fix RSS feed. TL;DR is that the feed controller was marked `internal` and no longer discoverable by the MVC framework.