### PR TITLE
General Cleanup

### DIFF
--- a/src/Coding.Blog/Coding.Blog.Client/Clients/BooksClient.cs
+++ b/src/Coding.Blog/Coding.Blog.Client/Clients/BooksClient.cs
@@ -2,6 +2,10 @@
 
 namespace Coding.Blog.Client.Clients;
 
+/// <summary>
+///     Wraps the <see cref="Books.BooksClient"/> to provide a more idiomatic, generic interface.
+/// </summary>
+/// <param name="booksClient">The <see cref="Books.BooksClient"/> to wrap.</param>
 internal sealed class BooksClient(Books.BooksClient booksClient) : IProtoClient<Book>
 {
     public async Task<IEnumerable<Book>> GetAsync()

--- a/src/Coding.Blog/Coding.Blog.Client/Clients/PostsClient.cs
+++ b/src/Coding.Blog/Coding.Blog.Client/Clients/PostsClient.cs
@@ -2,6 +2,10 @@
 
 namespace Coding.Blog.Client.Clients;
 
+/// <summary>
+///     Wraps the <see cref="Posts.PostsClient"/> to provide a more idiomatic, generic interface.
+/// </summary>
+/// <param name="postsClient">The <see cref="Posts.PostsClient"/> to wrap.</param>
 internal sealed class PostsClient(Posts.PostsClient postsClient) : IProtoClient<Post>
 {
     public async Task<IEnumerable<Post>> GetAsync()

--- a/src/Coding.Blog/Coding.Blog.Client/Clients/ProjectsClient.cs
+++ b/src/Coding.Blog/Coding.Blog.Client/Clients/ProjectsClient.cs
@@ -2,6 +2,10 @@
 
 namespace Coding.Blog.Client.Clients;
 
+/// <summary>
+///     Wraps the <see cref="Projects.ProjectsClient"/> to provide a more idiomatic, generic interface.
+/// </summary>
+/// <param name="projectsClient">The <see cref="Projects.ProjectsClient"/> to wrap.</param>
 internal sealed class ProjectsClient(Projects.ProjectsClient projectsClient) : IProtoClient<Project>
 {
     public async Task<IEnumerable<Project>> GetAsync()

--- a/src/Coding.Blog/Coding.Blog.Client/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Coding.Blog/Coding.Blog.Client/Extensions/ServiceCollectionExtensions.cs
@@ -24,6 +24,12 @@ namespace Coding.Blog.Client.Extensions;
 
 internal static class ServiceCollectionExtensions
 {
+    /// <summary>
+    ///     Configure the necessary services for the application.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configuration">The configuration.</param>
+    /// <returns>The configured service collection.</returns>
     public static IServiceCollection ConfigureServices(this IServiceCollection services, IConfiguration configuration) => services
         .AddSingleton(_ => new MarkdownPipelineBuilder()
             .UseAdvancedExtensions()
@@ -40,9 +46,9 @@ internal static class ServiceCollectionExtensions
         .AddSingleton<IBlogService<Post>, BlogService<ProtoPost, Post>>()
         .AddSingleton<IBlogService<Book>, BlogService<ProtoBook, Book>>()
         .AddSingleton<IBlogService<Project>, BlogService<ProtoProject, Project>>()
-        .AddSingleton<IApplicationStateService<Post>, ApplicationStateService<Post>>()
-        .AddSingleton<IApplicationStateService<Book>, ApplicationStateService<Book>>()
-        .AddSingleton<IApplicationStateService<Project>, ApplicationStateService<Project>>()
+        .AddSingleton<IPersistentComponentStateService<Post>, PersistentComponentStateService<Post>>()
+        .AddSingleton<IPersistentComponentStateService<Book>, PersistentComponentStateService<Book>>()
+        .AddSingleton<IPersistentComponentStateService<Project>, PersistentComponentStateService<Project>>()
         .AddSingleton<IJSInteropService, JSInteropService>()
         .AddGrpc(configuration);
 

--- a/src/Coding.Blog/Coding.Blog.Client/Pages/Blog.razor
+++ b/src/Coding.Blog/Coding.Blog.Client/Pages/Blog.razor
@@ -62,9 +62,9 @@
 
     protected override async Task OnInitializedAsync()
     {
-        _persistingComponentStateSubscription = ApplicationState.RegisterOnPersisting(PersistData);
+        _persistingComponentStateSubscription = PersistentComponentState.RegisterOnPersisting(PersistData);
 
-        var posts = await PostApplicationStateService.GetAsync(ApplicationState, Post.Key);
+        var posts = await PostsService.GetAsync(PersistentComponentState, Post.Key);
 
         Posts = PostLinker.Link(posts).ToList();
 
@@ -98,7 +98,7 @@
 
     private Task PersistData()
     {
-        ApplicationState.PersistAsJson(Post.Key, Posts);
+        PersistentComponentState.PersistAsJson(Post.Key, Posts);
 
         return Task.CompletedTask;
     }

--- a/src/Coding.Blog/Coding.Blog.Client/Pages/PostDetails.razor
+++ b/src/Coding.Blog/Coding.Blog.Client/Pages/PostDetails.razor
@@ -104,7 +104,8 @@
 
 @code {
 
-    [Parameter] public string Slug { get; set; } = string.Empty;
+    [Parameter] 
+    public string Slug { get; set; } = string.Empty;
 
     private PersistingComponentStateSubscription _persistingComponentStateSubscription;
 
@@ -114,22 +115,13 @@
 
     private string Title => _selectedPost?.Title ?? string.Empty;
 
-    protected override async Task OnInitializedAsync()
-    {
-        _persistingComponentStateSubscription = ApplicationState.RegisterOnPersisting(PersistData);
-
-        await RefreshPostAsync();
-    }
-
     protected override Task OnParametersSetAsync() => RefreshPostAsync();
 
-    private async Task RefreshPostAsync()
+    protected override async Task OnInitializedAsync()
     {
-        var posts = await PostApplicationStateService.GetAsync(ApplicationState, Post.Key);
+        _persistingComponentStateSubscription = PersistentComponentState.RegisterOnPersisting(PersistData);
 
-        Posts = PostLinker.Link(posts).ToList();
-
-        _selectedPost = Posts.FirstOrDefault(post => post.Slug == Slug);
+        await RefreshPostAsync();
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -138,9 +130,18 @@
         await JSInteropService.LoadGiscusAsync();
     }
 
+    private async Task RefreshPostAsync()
+    {
+        var posts = await PostsService.GetAsync(PersistentComponentState, Post.Key);
+
+        Posts = PostLinker.Link(posts);
+
+        _selectedPost = Posts.FirstOrDefault(post => post.Slug == Slug);
+    }
+
     private Task PersistData()
     {
-        ApplicationState.PersistAsJson(Post.Key, Posts);
+        PersistentComponentState.PersistAsJson(Post.Key, Posts);
 
         return Task.CompletedTask;
     }

--- a/src/Coding.Blog/Coding.Blog.Client/Pages/PostDetails.razor.css
+++ b/src/Coding.Blog/Coding.Blog.Client/Pages/PostDetails.razor.css
@@ -38,5 +38,4 @@
         padding-top: 0.1rem;
         padding-bottom: 0rem;
     }
-
 }

--- a/src/Coding.Blog/Coding.Blog.Client/Pages/Projects.razor
+++ b/src/Coding.Blog/Coding.Blog.Client/Pages/Projects.razor
@@ -19,6 +19,11 @@
             }
             else
             {
+                <div>
+                    <p>
+                        Here is a small sample of the open source projects that I maintain. They span websites, libraries, and command line applications. Each project is hosted on <a href="https://github.com/wbaldoumas" target="_blank" aria-label="GitHub link" rel="noopener noreferrer">GitHub</a> and is available for anyone to use, modify, and contribute to.
+                    </p>
+                </div>
                 <div class="row">
                     @foreach (var project in _projects.OrderBy(project => project.Rank))
                     {
@@ -26,7 +31,7 @@
                             <div class="card mb-3 border-0 shadow">
                                 <div class="row g-0">
                                     <div class="col-md-4 d-flex align-items-center card-img-container">
-                                        <img src="@project.Image.ImgixUrl" class="card-img-top" alt="@project.Title">
+                                        <img src="@project.Image.ImgixUrl" loading="lazy" class="card-img-top" alt="@project.Title">
                                     </div>
                                     <div class="col-md-8">
                                         <div class="card-body rounded">
@@ -58,16 +63,16 @@
 
     protected override async Task OnInitializedAsync()
     {
-        _persistingComponentStateSubscription = ApplicationState.RegisterOnPersisting(PersistData);
+        _persistingComponentStateSubscription = PersistentComponentState.RegisterOnPersisting(PersistData);
 
-        _projects = await ProjectApplicationStateService.GetAsync(ApplicationState, Project.Key);
+        _projects = await ProjectsService.GetAsync(PersistentComponentState, Project.Key);
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender) => await JSInteropService.ResetScrollPositionAsync();
 
     private Task PersistData()
     {
-        ApplicationState.PersistAsJson(Project.Key, _projects);
+        PersistentComponentState.PersistAsJson(Project.Key, _projects);
 
         return Task.CompletedTask;
     }

--- a/src/Coding.Blog/Coding.Blog.Client/Pages/Reading.razor
+++ b/src/Coding.Blog/Coding.Blog.Client/Pages/Reading.razor
@@ -59,16 +59,16 @@
 
     protected override async Task OnInitializedAsync()
     {
-        _persistingComponentStateSubscription = ApplicationState.RegisterOnPersisting(PersistData);
+        _persistingComponentStateSubscription = PersistentComponentState.RegisterOnPersisting(PersistData);
 
-        Books = await BookApplicationStateService.GetAsync(ApplicationState, Book.Key);
+        Books = await BooksService.GetAsync(PersistentComponentState, Book.Key);
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender) => await JSInteropService.ResetScrollPositionAsync();
 
     private Task PersistData()
     {
-        ApplicationState.PersistAsJson(Book.Key, Books);
+        PersistentComponentState.PersistAsJson(Book.Key, Books);
 
         return Task.CompletedTask;
     }

--- a/src/Coding.Blog/Coding.Blog.Client/Services/BlogService.cs
+++ b/src/Coding.Blog/Coding.Blog.Client/Services/BlogService.cs
@@ -4,6 +4,13 @@ using Coding.Blog.Library.Utilities;
 
 namespace Coding.Blog.Client.Services;
 
+/// <summary>
+///     A client-side service for retrieving blog data.
+/// </summary>
+/// <typeparam name="TProtoObject">The type of object to retrieve from the gRPC API.</typeparam>
+/// <typeparam name="TDomainObject">The type of the domain object to return.</typeparam>
+/// <param name="client">A gRPC client for retrieving the <see cref="TProtoObject"/> from the gRPC API.</param>
+/// <param name="mapper">A mapper for mapping the <see cref="TProtoObject"/> to the <see cref="TDomainObject"/>.</param>
 internal sealed class BlogService<TProtoObject, TDomainObject>(IProtoClient<TProtoObject> client, IMapper mapper) : IBlogService<TDomainObject>
 {
     public async Task<IEnumerable<TDomainObject>> GetAsync()

--- a/src/Coding.Blog/Coding.Blog.Client/Utilities/Mapper.cs
+++ b/src/Coding.Blog/Coding.Blog.Client/Utilities/Mapper.cs
@@ -10,6 +10,9 @@ using ProtoProject = Coding.Blog.Library.Protos.Project;
 
 namespace Coding.Blog.Client.Utilities;
 
+/// <summary>
+///     A mapper for mapping between different types.
+/// </summary>
 [Mapper]
 internal sealed partial class Mapper : IMapper
 {

--- a/src/Coding.Blog/Coding.Blog.Client/_Imports.razor
+++ b/src/Coding.Blog/Coding.Blog.Client/_Imports.razor
@@ -18,10 +18,10 @@
 @using Coding.Blog.Client.Services
 @using Coding.Blog.Library.Utilities
 
-@inject IApplicationStateService<Post> PostApplicationStateService
-@inject IApplicationStateService<Book> BookApplicationStateService
-@inject IApplicationStateService<Project> ProjectApplicationStateService
-@inject PersistentComponentState ApplicationState
+@inject IPersistentComponentStateService<Post> PostsService
+@inject IPersistentComponentStateService<Book> BooksService
+@inject IPersistentComponentStateService<Project> ProjectsService
+@inject PersistentComponentState PersistentComponentState
 @inject MarkdownPipeline MarkdownPipeline
 @inject NavigationManager NavigationManager
 @inject IPostLinker PostLinker

--- a/src/Coding.Blog/Coding.Blog.Library/Extensions/DateTimeExtensions.cs
+++ b/src/Coding.Blog/Coding.Blog.Library/Extensions/DateTimeExtensions.cs
@@ -6,5 +6,10 @@ public static class DateTimeExtensions
 {
     private const string _format = "D";
 
+    /// <summary>
+    ///     Formats the given date time in a unified way for the blog.
+    /// </summary>
+    /// <param name="source">The source date time to format.</param>
+    /// <returns>The formatted date time.</returns>
     public static string ToPreformattedString(this DateTime source) => source.ToString(_format, CultureInfo.InvariantCulture);
 }

--- a/src/Coding.Blog/Coding.Blog.Library/Extensions/StringExtensions.cs
+++ b/src/Coding.Blog/Coding.Blog.Library/Extensions/StringExtensions.cs
@@ -5,8 +5,19 @@ namespace Coding.Blog.Library.Extensions;
 
 public static class StringExtensions
 {
+    /// <summary>
+    ///     Converts the given string to a <see cref="MarkupString"/>.
+    /// </summary>
+    /// <param name="source">The source string to convert.</param>
+    /// <param name="markdownPipeline">A <see cref="MarkdownPipeline"/> to use for the conversion.</param>
+    /// <returns>The converted <see cref="MarkupString"/>.</returns>
     public static MarkupString ToMarkupString(this string source, MarkdownPipeline markdownPipeline) => new(Markdown.ToHtml(source, markdownPipeline));
 
+    /// <summary>
+    ///     Parses the given string into a collection of display tags.
+    /// </summary>
+    /// <param name="source">The source string to parse.</param>
+    /// <returns>The collection of display tags.</returns>
     public static IEnumerable<string> ToDisplayTags(this string source) => source.Trim().Length > 0
         ? source.Split(",").Select(tag => tag.Trim())
         : Array.Empty<string>();

--- a/src/Coding.Blog/Coding.Blog.Library/Services/IApplicationStateService.cs
+++ b/src/Coding.Blog/Coding.Blog.Library/Services/IApplicationStateService.cs
@@ -1,8 +1,0 @@
-﻿using Microsoft.AspNetCore.Components;
-
-namespace Coding.Blog.Library.Services;
-
-public interface IApplicationStateService<T>
-{
-    Task<IList<T>> GetAsync(PersistentComponentState persistentComponentState, string key);
-}

--- a/src/Coding.Blog/Coding.Blog.Library/Services/IJSInteropService.cs
+++ b/src/Coding.Blog/Coding.Blog.Library/Services/IJSInteropService.cs
@@ -1,5 +1,8 @@
 ﻿namespace Coding.Blog.Library.Services;
 
+/// <summary>
+///    A service encapsulating JS interop calls.
+/// </summary>
 public interface IJSInteropService
 {
     ValueTask ResetScrollPositionAsync();

--- a/src/Coding.Blog/Coding.Blog.Library/Services/IPersistentComponentStateService.cs
+++ b/src/Coding.Blog/Coding.Blog.Library/Services/IPersistentComponentStateService.cs
@@ -1,0 +1,12 @@
+﻿using Microsoft.AspNetCore.Components;
+
+namespace Coding.Blog.Library.Services;
+
+/// <summary>
+///    A service for retrieving data from <see cref="PersistentComponentState"/> or static state.
+/// </summary>
+/// <typeparam name="T">The type of object to retrieve</typeparam>
+public interface IPersistentComponentStateService<T>
+{
+    Task<IList<T>> GetAsync(PersistentComponentState persistentComponentState, string key);
+}

--- a/src/Coding.Blog/Coding.Blog.Library/Services/JSInteropService.cs
+++ b/src/Coding.Blog/Coding.Blog.Library/Services/JSInteropService.cs
@@ -2,6 +2,9 @@
 
 namespace Coding.Blog.Library.Services;
 
+/// <summary>
+///    A service encapsulating JS interop calls.
+/// </summary>
 public sealed class JSInteropService(IJSRuntime jsRuntime) : IJSInteropService
 {
     public ValueTask ResetScrollPositionAsync() => jsRuntime.InvokeVoidAsync("resetScrollPosition");

--- a/src/Coding.Blog/Coding.Blog.Library/Services/PersistentComponentStateService.cs
+++ b/src/Coding.Blog/Coding.Blog.Library/Services/PersistentComponentStateService.cs
@@ -3,7 +3,12 @@ using Microsoft.AspNetCore.Components;
 
 namespace Coding.Blog.Library.Services;
 
-public sealed class ApplicationStateService<T>(IBlogService<T> blogService) : IApplicationStateService<T>
+/// <summary>
+///    A service for retrieving data from <see cref="PersistentComponentState"/> or static state.
+/// </summary>
+/// <typeparam name="T">The type of object to retrieve</typeparam>
+/// <param name="blogService">A <see cref="IBlogService{T}"/> for retrieving the data from the server when not found in state.</param>
+public sealed class PersistentComponentStateService<T>(IBlogService<T> blogService) : IPersistentComponentStateService<T>
 {
     public async Task<IList<T>> GetAsync(PersistentComponentState persistentComponentState, string key)
     {

--- a/src/Coding.Blog/Coding.Blog.Library/Utilities/IMapper.cs
+++ b/src/Coding.Blog/Coding.Blog.Library/Utilities/IMapper.cs
@@ -1,5 +1,8 @@
 ﻿namespace Coding.Blog.Library.Utilities;
 
+/// <summary>
+///     A simple mapper for mapping objects from one type to another.
+/// </summary>
 public interface IMapper
 {
     TTarget Map<TSource, TTarget>(TSource source);

--- a/src/Coding.Blog/Coding.Blog.Library/Utilities/IPostLinker.cs
+++ b/src/Coding.Blog/Coding.Blog.Library/Utilities/IPostLinker.cs
@@ -2,6 +2,9 @@
 
 namespace Coding.Blog.Library.Utilities;
 
+/// <summary>
+///     Links the given posts to one another, hydrating the <see cref="Post.Next"/> and <see cref="Post.Previous"/> properties.
+/// </summary>
 public interface IPostLinker
 {
     IEnumerable<Post> Link(IEnumerable<Post> posts);

--- a/src/Coding.Blog/Coding.Blog.Library/Utilities/PostLinker.cs
+++ b/src/Coding.Blog/Coding.Blog.Library/Utilities/PostLinker.cs
@@ -2,6 +2,9 @@
 
 namespace Coding.Blog.Library.Utilities;
 
+/// <summary>
+///     Links the given posts to one another sequentially by date, hydrating the <see cref="Post.Next"/> and <see cref="Post.Previous"/> properties.
+/// </summary>
 public sealed class PostLinker : IPostLinker
 {
     public IEnumerable<Post> Link(IEnumerable<Post> posts)

--- a/src/Coding.Blog/Coding.Blog.Library/Utilities/SyntaxHighlighting.cs
+++ b/src/Coding.Blog/Coding.Blog.Library/Utilities/SyntaxHighlighting.cs
@@ -3,6 +3,9 @@ using ColorCode.Styling;
 
 namespace Coding.Blog.Library.Utilities;
 
+/// <summary>
+///     Custom syntax highlighting colors.
+/// </summary>
 public static class SyntaxHighlighting
 {
     public const string Blue = "#FF0000FF";

--- a/src/Coding.Blog/Coding.Blog/Coding.Blog.csproj
+++ b/src/Coding.Blog/Coding.Blog/Coding.Blog.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Blazorise.Icons.FontAwesome" Version="1.4.1" />
+    <PackageReference Include="Blazorise.Icons.FontAwesome" Version="1.4.2" />
     <PackageReference Include="Flurl.Http" Version="4.0.2" />
     <PackageReference Include="Grpc.AspNetCore" Version="2.60.0" />
     <PackageReference Include="Grpc.AspNetCore.Web" Version="2.60.0" />

--- a/src/Coding.Blog/Coding.Blog/Controllers/RssFeedController.cs
+++ b/src/Coding.Blog/Coding.Blog/Controllers/RssFeedController.cs
@@ -6,6 +6,10 @@ using System.Xml;
 
 namespace Coding.Blog.Controllers;
 
+/// <summary>
+///     Generate an RSS feed for the blog.
+/// </summary>
+/// <param name="syndicationFeedService"> The service to retrieve the syndication feed from. </param>
 public sealed class RssFeedController(ISyndicationFeedService syndicationFeedService) : ControllerBase
 {
     [HttpGet]
@@ -14,7 +18,6 @@ public sealed class RssFeedController(ISyndicationFeedService syndicationFeedSer
     public async Task<IActionResult> GetRssFeedAsync()
     {
         var syndicationUrl = $"{Request.Scheme}://{Request.Host}{Request.PathBase}";
-
         var syndicationFeed = await syndicationFeedService.GetSyndicationFeed(syndicationUrl).ConfigureAwait(false);
 
         using var memoryStream = new MemoryStream();

--- a/src/Coding.Blog/Coding.Blog/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Coding.Blog/Coding.Blog/Extensions/ServiceCollectionExtensions.cs
@@ -91,9 +91,9 @@ internal static class ServiceCollectionExtensions
         .AddSingleton<IBlogService<Book>, BlogService<CosmicBook, Book>>()
         .AddSingleton<IBlogService<Project>, BlogService<CosmicProject, Project>>()
         .AddScoped<IJSInteropService, JSInteropService>()
-        .AddSingleton<IApplicationStateService<Post>, ApplicationStateService<Post>>()
-        .AddSingleton<IApplicationStateService<Book>, ApplicationStateService<Book>>()
-        .AddSingleton<IApplicationStateService<Project>, ApplicationStateService<Project>>();
+        .AddSingleton<IPersistentComponentStateService<Post>, PersistentComponentStateService<Post>>()
+        .AddSingleton<IPersistentComponentStateService<Book>, PersistentComponentStateService<Book>>()
+        .AddSingleton<IPersistentComponentStateService<Project>, PersistentComponentStateService<Project>>();
 
     private static IServiceCollection AddUtilities(this IServiceCollection services) => services
         .AddSingleton(_ => new MarkdownPipelineBuilder()

--- a/src/Coding.Blog/Coding.Blog/Jobs/CacheWarmingJob.cs
+++ b/src/Coding.Blog/Coding.Blog/Jobs/CacheWarmingJob.cs
@@ -4,6 +4,12 @@ using Quartz;
 
 namespace Coding.Blog.Jobs;
 
+/// <summary>
+///     A generic cache warming job for warming the cache of a <see cref="ICosmicClient{T}"/>.
+/// </summary>
+/// <typeparam name="T">The type of object to warm the cache for</typeparam>
+/// <param name="client"> The <see cref="ICosmicClient{T}"/> to warm the cache for</param>
+/// <param name="logger"> A <see cref="ILogger{T}"/> for logging</param>
 internal sealed class CacheWarmingJob<T>(ICosmicClient<T> client, ILogger<CacheWarmingJob<T>> logger) : IJob
 {
     public async Task Execute(IJobExecutionContext context)

--- a/src/Coding.Blog/Coding.Blog/Services/ApplicationLifetimeService.cs
+++ b/src/Coding.Blog/Coding.Blog/Services/ApplicationLifetimeService.cs
@@ -4,6 +4,11 @@ using Microsoft.Extensions.Options;
 
 namespace Coding.Blog.Services;
 
+/// <summary>
+///     Ensures that the application stops gracefully.
+/// </summary>
+/// <param name="hostApplicationLifetime"> The host application lifetime, leveraged to register the application stopping event. </param>
+/// <param name="options"> The application lifetime options. </param>
 [ExcludeFromCodeCoverage]
 internal sealed class ApplicationLifetimeService(
     IHostApplicationLifetime hostApplicationLifetime,

--- a/src/Coding.Blog/Coding.Blog/Services/BlogService.cs
+++ b/src/Coding.Blog/Coding.Blog/Services/BlogService.cs
@@ -4,6 +4,13 @@ using Coding.Blog.Library.Utilities;
 
 namespace Coding.Blog.Services;
 
+/// <summary>
+///     A generic service for retrieving blog posts from the Cosmic API and mapping them to domain objects.
+/// </summary>
+/// <typeparam name="TCosmicObject"> The type of object to retrieve from the Cosmic API. </typeparam>
+/// <typeparam name="TDomainObject"> The type of object to map to. </typeparam>
+/// <param name="client"> The client to retrieve the objects from. </param>
+/// <param name="mapper"> The mapper to map the objects to domain objects. </param>
 internal sealed class BlogService<TCosmicObject, TDomainObject>(ICosmicClient<TCosmicObject> client, IMapper mapper) : IBlogService<TDomainObject>
 {
     public async Task<IEnumerable<TDomainObject>> GetAsync()

--- a/src/Coding.Blog/Coding.Blog/Services/BooksService.cs
+++ b/src/Coding.Blog/Coding.Blog/Services/BooksService.cs
@@ -6,6 +6,11 @@ using Grpc.Core;
 
 namespace Coding.Blog.Services;
 
+/// <summary>
+///     A gRPC service for the Books endpoint.
+/// </summary>
+/// <param name="client">The <see cref="ICosmicClient{T}"/> to retrieve books from.</param>
+/// <param name="mapper">A <see cref="IMapper"/> for mapping objects to their protobuf representations.</param>
 internal sealed class BooksService(ICosmicClient<CosmicBook> client, IMapper mapper) : Books.BooksBase
 {
     public override async Task<BooksReply> GetBooks(BooksRequest request, ServerCallContext context)

--- a/src/Coding.Blog/Coding.Blog/Services/ISyndicationFeedService.cs
+++ b/src/Coding.Blog/Coding.Blog/Services/ISyndicationFeedService.cs
@@ -2,6 +2,9 @@
 
 namespace Coding.Blog.Services;
 
+/// <summary>
+///     A service for generating a <see cref="SyndicationFeed"/> from a given URL.
+/// </summary>
 public interface ISyndicationFeedService
 {
     Task<SyndicationFeed> GetSyndicationFeed(string syndicationUrl);

--- a/src/Coding.Blog/Coding.Blog/Services/PostsService.cs
+++ b/src/Coding.Blog/Coding.Blog/Services/PostsService.cs
@@ -6,6 +6,11 @@ using Grpc.Core;
 
 namespace Coding.Blog.Services;
 
+/// <summary>
+///     A gRPC service for the posts endpoint.
+/// </summary>
+/// <param name="client">The <see cref="ICosmicClient{T}"/> to retrieve posts from.</param>
+/// <param name="mapper">A <see cref="IMapper"/> for mapping objects to their protobuf representations.</param>
 internal sealed class PostsService(ICosmicClient<CosmicPost> client, IMapper mapper) : Posts.PostsBase
 {
     public override async Task<PostsReply> GetPosts(PostsRequest request, ServerCallContext context)

--- a/src/Coding.Blog/Coding.Blog/Services/ProjectsService.cs
+++ b/src/Coding.Blog/Coding.Blog/Services/ProjectsService.cs
@@ -6,6 +6,11 @@ using Grpc.Core;
 
 namespace Coding.Blog.Services;
 
+/// <summary>
+///     A gRPC service for the projects endpoint.
+/// </summary>
+/// <param name="client">The <see cref="ICosmicClient{T}"/> to retrieve projects from.</param>
+/// <param name="mapper">A <see cref="IMapper"/> for mapping objects to their protobuf representations.</param>
 internal sealed class ProjectsService(ICosmicClient<CosmicProject> client, IMapper mapper) : Projects.ProjectsBase
 {
     public override async Task<ProjectsReply> GetProjects(ProjectsRequest request, ServerCallContext context)

--- a/src/Coding.Blog/Coding.Blog/Services/SyndicationFeedService.cs
+++ b/src/Coding.Blog/Coding.Blog/Services/SyndicationFeedService.cs
@@ -7,6 +7,12 @@ using System.ServiceModel.Syndication;
 
 namespace Coding.Blog.Services;
 
+/// <summary>
+///     A service for generating a <see cref="SyndicationFeed"/> from a given URL.
+/// </summary>
+/// <param name="applicationInfoOptions">The application info options.</param>
+/// <param name="blogPostService">The blog post service to retrieve post information to inject into the feed.</param>
+/// <param name="mapper">A mapper for mapping a post to a syndication feed item.</param>
 internal sealed class SyndicationFeedService(
     IOptions<ApplicationInfoOptions> applicationInfoOptions,
     IBlogService<Post> blogPostService,

--- a/src/Coding.Blog/Coding.Blog/Utilities/IPostToSyndicationItemMapper.cs
+++ b/src/Coding.Blog/Coding.Blog/Utilities/IPostToSyndicationItemMapper.cs
@@ -3,6 +3,9 @@ using Coding.Blog.Library.Domain;
 
 namespace Coding.Blog.Utilities;
 
+/// <summary>
+///     Maps a <see cref="Post"/> to a <see cref="SyndicationItem"/>.
+/// </summary>
 internal interface IPostToSyndicationItemMapper
 {
     SyndicationItem Map(string syndicationUrl, Post post);

--- a/src/Coding.Blog/Coding.Blog/Utilities/Mapper.cs
+++ b/src/Coding.Blog/Coding.Blog/Utilities/Mapper.cs
@@ -11,6 +11,10 @@ using ProtoProject = Coding.Blog.Library.Protos.Project;
 
 namespace Coding.Blog.Utilities;
 
+/// <summary>
+///     A mapper for mapping between different types.
+/// </summary>
+/// <param name="readTimeEstimator">A read time estimator, used for generating mapped reading times.</param>
 [Mapper]
 internal sealed partial class Mapper(IReadTimeEstimator readTimeEstimator) : IMapper
 {

--- a/src/Coding.Blog/Coding.Blog/Utilities/PostToSyndicationItemMapper.cs
+++ b/src/Coding.Blog/Coding.Blog/Utilities/PostToSyndicationItemMapper.cs
@@ -4,6 +4,10 @@ using System.Xml.Linq;
 
 namespace Coding.Blog.Utilities;
 
+/// <summary>
+///    Maps a <see cref="Post"/> to a <see cref="SyndicationItem"/>.
+/// </summary>
+/// <param name="stringSanitizer">A <see cref="IStringSanitizer"/> for sanitizing strings.</param>
 internal sealed class PostToSyndicationItemMapper(IStringSanitizer stringSanitizer) : IPostToSyndicationItemMapper
 {
     public SyndicationItem Map(string syndicationUrl, Post post)

--- a/src/Coding.Blog/Coding.Blog/Utilities/ReadTimeEstimator.cs
+++ b/src/Coding.Blog/Coding.Blog/Utilities/ReadTimeEstimator.cs
@@ -1,5 +1,9 @@
 ﻿namespace Coding.Blog.Utilities;
 
+/// <summary>
+///     A service for estimating the read time of a given string.
+/// </summary>
+/// <param name="sanitizer">A <see cref="IStringSanitizer"/> for sanitizing the string.</param>
 internal sealed class ReadTimeEstimator(IStringSanitizer sanitizer) : IReadTimeEstimator
 {
     private const double AverageWordsPerMinute = 250.00;

--- a/src/Coding.Blog/Coding.Blog/Utilities/StringSanitizer.cs
+++ b/src/Coding.Blog/Coding.Blog/Utilities/StringSanitizer.cs
@@ -2,6 +2,10 @@
 
 namespace Coding.Blog.Utilities;
 
+/// <summary>
+///     A utility for sanitizing strings.
+/// </summary>
+/// <param name="markdownPipeline">A <see cref="MarkdownPipeline"/> for converting markdown to plaintext.</param>
 internal sealed class StringSanitizer(MarkdownPipeline markdownPipeline) : IStringSanitizer
 {
     // For now, just convert the markdown to plaintext. This method may be extended later.


### PR DESCRIPTION
- Add some nice doc comments to interfaces and implementations, without too much detail
- Rename `IApplicationStateService` and `ApplicationStateService` to `IPersistentComponentStateService` and `PersistentComponentStateService` respectively, to better reflect their purpose
- Add blurb to the top of the projects page