### PR TITLE
Configure Codecov

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "**/*.razor"


### PR DESCRIPTION
Ignore Razor components in coverage checks (for now) until bUnit is up and running.