### PR TITLE
Support Interpolated String Syntax Highlighting

### DIFF
--- a/src/Coding.Blog/Coding.Blog.Library/Utilities/CSharpOverride.cs
+++ b/src/Coding.Blog/Coding.Blog.Library/Utilities/CSharpOverride.cs
@@ -56,6 +56,30 @@ public sealed class CSharpOverride : ILanguage
                     { 0, ScopeName.StringCSharpVerbatim }
                 }),
             new(
+                @"(\$""[^""]*\{)([^{}]*)(\}[^""]*\{)([^{}]*)(\}[^""]*\{)([^{}]*)(\}.*?"")",
+                new Dictionary<int, string>
+                {
+                    { 1, ScopeName.String },
+                    { 3, ScopeName.String },
+                    { 5, ScopeName.String },
+                    { 7, ScopeName.String }
+                }),
+            new(
+                @"(\$""[^""]*\{)([^{}]*)(\}[^""]*\{)([^{}]*)(\}.*?"")",
+                new Dictionary<int, string>
+                {
+                    { 1, ScopeName.String },
+                    { 3, ScopeName.String },
+                    { 5, ScopeName.String }
+                }),
+            new(
+                @"(\$""[^""]*\{)([^{}]*)(\}.*?"")",
+                new Dictionary<int, string>
+                {
+                    { 1, ScopeName.String },
+                    { 3, ScopeName.String }
+                }),
+            new(
                 @"(?s)(""[^\n]*?(?<!\\)"")",
                 new Dictionary<int, string>
                 {


### PR DESCRIPTION
Adds language rules to support correctly syntax highlighting interpolated strings, with up to three interpolated values.